### PR TITLE
translate `manual` from `types` to `modules`

### DIFF
--- a/TranslationTable.md
+++ b/TranslationTable.md
@@ -49,7 +49,7 @@
 | type promotion and conversion mechanism         | 型プロモーションと変換機構                       
 | significand                                     | 仮数                                     
 | Numeric Literal Coefficients                    | 数値リテラル係数                             
-| promotion system                                | プロモーションシステム                              
+| promotion system                                | プロモーションシステム,昇格システム                     
 | operand                                         | 被演算子                                 
 | binary operator                                 | 二項演算子                               
 | primitive numeric type / numeric primitive type | 数値プリミティブ型                             
@@ -66,7 +66,7 @@
 | assignment form                                 | 代入形式、代入方式                       
 | anonymous function                              | 無名関数                                 
 | tuple                                           | タプル                                      
-| tuple “destructuring”       　                  | タプル「構造解除」、タプルの「分割」                
+| tuple “destructuring”                         | タプル「構造解除」、タプルの「分割」                
 | varargs,variable argument                       | 可変引数                                 
 | Parametrically-constrained Varargs methods      | パラメトリック制約付き可変引数メソッド               
 | Performance Tip                                 | パフォーマンスに関するヒント                          
@@ -80,7 +80,7 @@
 | scope rule                                      | スコープ規則                                 
 | region of code                                  | スコープの範囲                                
 | lexical scope                                   | レキシカルスコープ                                
-| comprehension                                   | コンプリヘンション 、内包表記                              
+| comprehension                                   | コンプリヘンション 、内包表記                     
 | static type system                              | 静的型付け                                
 | dynamic type system                             | 動的型付け                                
 | polymorphism                                    | ポリモーフィズム                                 
@@ -90,15 +90,15 @@
 | singleton                                       | 単体                                     
 | parametric type                                 | パラメータ型                                  
 | composite                                       | コンポジット                                   
-| generic programming                             | 汎用プログラミング                              
+| generic programming                             | 汎用プログラミング、汎化プログラミング                 
 | parametric polymorphism                         | パラメトリック多様型                            
 | Singleton Types                                 | シングルトン型                                 
 | signature                                       | 特徴                                     
-| catch-all                                       | 包括的な                                  
+| catch-all                                       | 包括的な、全捕捉                          
 | core operations                                 | コアオペレーション                                
 | functor                                         | functor                                  
-| outer constructor methods                       | アウターコンストラクタメソッド                          
-| inner constructor methods                       | インナーコンストラクタメソッド                          
+| outer constructor methods                       | アウターコンストラクタメソッド、外部コンストラクタメソッド         
+| inner constructor methods                       | インナーコンストラクタメソッド 、内部コンストラクタメソッド        
 | conversion and promotion                        | 変換とプロモーション                             
 | lossless conversion                             | 可逆変換                                 
 | interface                                       | インタフェース                                  
@@ -107,7 +107,7 @@
 | fenced code block                               | 分離コードブロック                              
 | Markdown                                        | マークダウン                                   
 | interned string                                 | intern文字列                             
-| prefix notation                                 | プレフィックス表記法                            
+| prefix notation                                 | プレフィックス表記法、前置記法                  
 | build step                                      | ビルド工程                                  
 | preprocessor                                    | プレプロセッサ                                  
 | quoted expression                               | 引用式                                   
@@ -119,12 +119,12 @@
 | pass-by-sharing                                 | 共有渡し                                  
 | compound expression                             | 複合式                                   
 | control flow                                    | 制御構造                                 
-| generic function                                | 総称関数                                 
+| generic function                                | 総称関数、汎化関数                       
 | type annotation                                 | 型注釈                                   
 | argument                                        | 引数                                     
 | return value                                    | 戻り値                                    
 | evaluation semantics                            | 評価戦略                                 
-| Optional Arguments                              | 省略可能引数                             
+| Optional Arguments                              | オプション引数                                
 | Conditional Evaluation                          | 条件評価                                 
 | Task                                            | タスク                                      
 | Channel                                         | チャネル                                     
@@ -138,15 +138,15 @@
 | pick up right where you left off                | 中断したところから再開する                        
 | lifetime                                        | 存続期間、寿命                           
 | blocking operations                             | 他を中断させる操作                           
-| `(;)` chain syntax                              | セミコロン(;)連鎖構文                         
-| `begin` blocks                                  | beginブロック                                
+| (;)?chain syntax                                | セミコロン(;)連鎖構文                         
+| begin?blocks                                    | beginブロック                                
 | unintuitive                                     | 直観に反する                                
 | precedence                                      | 優先順位                                 
 | associativity                                   | 結合性                                   
 | contrived                                       | 不自然な                                  
 | cartesian product                               | 直積                                     
 | symmetric coroutines                            | 対称コルーチン                                
-| lightweight　threads                            | 軽量スレッド                                 
+| lightweight　threads                             | 軽量スレッド                                 
 | cooperative multitasking                        | 協調的マルチタスク                             
 | one-shot continuations                          | ワンショット継続                               
 | first-in first-out                              | 先入先出                                 
@@ -166,3 +166,53 @@
 | namespace                                       | 名前空間                                 
 | closures                                        | クロージャ                                    
 | iteration                                       | 繰返し                                    
+| Abstract Type                                   | 抽象型                                   
+| Primitive Types                                 | 原始型                                   
+| Composite Types                                 | 複合型                                   
+| Type Unions                                     | 合併型                                   
+| Type Aliases                                    | 型の別名                                  
+| Value types                                     | 値型                                     
+| Nullable Types                                  | null許容型                               
+| concrete type                                   | 具象型                                   
+| Declared Types                                  | 宣言型                                   
+| umbrella type                                   | 包括型                                   
+| Missing Values                                  | 欠損値                                   
+| type assertion                                  | 型表明                                   
+| assertion                                       | 表明                                     
+| nominative                                      | 公称的                                   
+| gotchas                                         | 落とし穴                                   
+| attached                                        | （宣言・表明を）差し込む                     
+| type graph                                      | 型のグラフ                                   
+| plain old                                       | 普通の                                    
+| bags of                                         | たくさんの                                    
+| go hand in hand                                 | 伴う,                                     
+| sidestep                                        | 避ける                                     
+| immediate values                                | 即値、リテラル                               
+| worth noting                                    | 注目に値する                                
+| recap                                           | まとめ                                      
+| unambiguous                                     | 曖昧さがない、明確な                          
+| exploit                                         | 利用する                                   
+| unobtrusive                                     | 目立たない                                  
+| final                                           | ファイナル                                    
+| fall under                                      | 当てはまる                                   
+| cascade                                         | 多段的に                                  
+| fallback                                        | フォールバック、補助的な、二次的な                
+| exported                                        | 公開した                                   
+| specific                                        | 特化した                                   
+| innocuous                                       | 無害の、問題ない                            
+| lowest term                                     | 既約分数                                 
+| lossless                                        | 可逆                                     
+| take a crack at                                 | 試みる                                     
+| to name a few                                   | 少し例を挙げると                              
+| interoperate                                    | 共用する、いっしょに使える、相互運用性がある         
+| tolerance                                       | 許容誤差                                 
+| not　strictly necessary                          | 必須ではない、必ずしも必要ない                    
+| building block                                  | 構成要素                                 
+| dedicated                                       | 専用の                                    
+| informal interface                              | 仮に実装されたインターフェース                       
+| indexing                                        | インデックスによる参照                            
+| indexed assignment                              | インデックスによる代入                            
+| accommodate                                     | 対応する                                   
+| incremental precompile                          | 逐次プリコンパイル                              
+| top-level definitions                           | 最上位の定義                              
+| name conflict                                   | 名前の競合                                

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -1,9 +1,20 @@
-# [Constructors](@id man-constructors)
+[](# [Constructors](@id man-constructors))
+# [コンストラクタ](@id man-constructors)
 
+
+```@raw html
+<!--
 Constructors [^1] are functions that create new objects -- specifically, instances of [Composite Types](@ref).
 In Julia, type objects also serve as constructor functions: they create new instances of themselves
 when applied to an argument tuple as a function. This much was already mentioned briefly when
 composite types were introduced. For example:
+-->
+```
+
+コンストラクタ[^ 1]は新しいオブジェクトを作成する関数で、特に[複合型](@ref)のインスタンスの場合に使用されます。
+Juliaでは、型オブジェクトはコンストラクタ関数としても機能して、引数となるタプルに適用すると、新しいインスタンスが作成されます。
+これは、複合型を紹介したときにすでに簡単に触れました。例えば、
+
 
 ```jldoctest footype
 julia> struct Foo
@@ -21,6 +32,9 @@ julia> foo.baz
 2
 ```
 
+
+```@raw html
+<!--
 For many types, forming new objects by binding their field values together is all that is ever
 needed to create instances. There are, however, cases where more functionality is required when
 creating composite objects. Sometimes invariants must be enforced, either by checking arguments
@@ -30,21 +44,51 @@ being created in an incomplete state and then altered programmatically to be mad
 separate step from object creation. Sometimes, it's just convenient to be able to construct objects
 with fewer or different types of parameters than they have fields. Julia's system for object construction
 addresses all of these cases and more.
+-->
+```
 
+多くの型では、インスタンスを作成する際には、各フィールド値を束縛して新しいオブジェクトを作成します。
+しかし、複合型のオブジェクトを作成するときにはより多くの機能が必要になる場合があります。
+時には、引数を検査したり変換したりして、強制的に不変にする必要があります。
+[再帰的なデータ構造](https://en.wikipedia.org/wiki/Recursion_%28computer_science%29#Recursive_data_structures_.28structural_recursion.29)、
+特に自己参照可能な構造は、オブジェクト作成とは別の過程として、はじめは不完全な状態で作成してからプログラムによって変更して全体を作らないと、きれいに構築できないことがよくあります。
+また時には、実際のフィールドと比べて、パラメータの数が少なかったり、型が異なっていたりするオブジェクトを構築できるのが便利な場合もあります。
+Juliaのオブジェクトコンストラクタは、これらのすべてのケースに対応しています。
+
+
+
+
+```@raw html
+<!--
 [^1]:
     Nomenclature: while the term "constructor" generally refers to the entire function which constructs
     objects of a type, it is common to abuse terminology slightly and refer to specific constructor
     methods as "constructors". In such situations, it is generally clear from context that the term
     is used to mean "constructor method" rather than "constructor function", especially as it is often
     used in the sense of singling out a particular method of the constructor from all of the others.
+-->
+```
+^ 1]：命名法：「コンストラクタ」という用語は、通常、ある型に対して、その型のオブジェクトを構成する関数全体を指しますが、用語を少し拡大解釈し、特定のコンストラクタメソッドも「コンストラクタ」と呼びます。このようにしても、コンストラクタ関数ではなく、コンストラクタメソッド、特にほかのすべてのメソッドの中から特定のコンストラクタメソッドを単独で指して使っている場合は、通常は文脈から分かります
 
-## Outer Constructor Methods
+[](## Outer Constructor Methods)
+## 外部コンストラクタメソッド
 
+
+
+```@raw html
+<!--
 A constructor is just like any other function in Julia in that its overall behavior is defined
 by the combined behavior of its methods. Accordingly, you can add functionality to a constructor
 by simply defining new methods. For example, let's say you want to add a constructor method for
 `Foo` objects that takes only one argument and uses the given value for both the `bar` and `baz`
 fields. This is simple:
+-->
+```
+コンストラクタは、Juliaの他の関数と同じように、全体の挙動はメソッドの挙動の組み合わせで定義されています。
+したがって、新しいメソッドを定義するだけで、コンストラクタに機能を追加できます。
+たとえば、`Foo`オブジェクトのコンストラクタメソッドを追加するとします。
+このオブジェクトは、1個だけの引数の値を、`bar`フィールドと`baz`フィールドの両方に使用する単純なものです。
+
 
 ```jldoctest footype
 julia> Foo(x) = Foo(x,x)
@@ -54,8 +98,14 @@ julia> Foo(1)
 Foo(1, 1)
 ```
 
+
+```@raw html
+<!--
 You could also add a zero-argument `Foo` constructor method that supplies default values for both
 of the `bar` and `baz` fields:
+-->
+```
+また、引数のない`Foo`コンストラクタメソッドを追加して、`bar`フィールドと`baz`フィールドの両方にデフォルト値を設定することもできます。
 
 ```jldoctest footype
 julia> Foo() = Foo(0)
@@ -65,14 +115,27 @@ julia> Foo()
 Foo(0, 0)
 ```
 
+
+```@raw html
+<!--
 Here the zero-argument constructor method calls the single-argument constructor method, which
 in turn calls the automatically provided two-argument constructor method. For reasons that will
 become clear very shortly, additional constructor methods declared as normal methods like this
 are called *outer* constructor methods. Outer constructor methods can only ever create a new instance
 by calling another constructor method, such as the automatically provided default ones.
+-->
+```
+ここでは、引数のないコンストラクタメソッドが、1引数のコンストラクタメソッドを呼び出し、続いて、自動的に生成される2引数のコンストラクタメソッドが呼び出されます。
+まもなく明らかにする理由から、このような通常のメソッドのように宣言して追加されたコンストラクタメソッドは、**外部**コンストラクタメソッドと呼ばれます。
+外部コンストラクタメソッドは、デフォルト値を自動的に提供するメソッドなど、別の既存のコンストラクタメソッドを呼び出す場合に限って、新しいインスタンスを作成することができます。
 
-## Inner Constructor Methods
 
+[](## Inner Constructor Methods)
+## 内部コンストラクタメソッド
+
+
+```@raw html
+<!--
 While outer constructor methods succeed in addressing the problem of providing additional convenience
 methods for constructing objects, they fail to address the other two use cases mentioned in the
 introduction of this chapter: enforcing invariants, and allowing construction of self-referential
@@ -82,10 +145,27 @@ is much like an outer constructor method, with two differences:
 1. It is declared inside the block of a type declaration, rather than outside of it like normal methods.
 2. It has access to a special locally existent function called `new` that creates objects of the
    block's type.
+-->
+```
+外部コンストラクタメソッドを使うと、オブジェクトを構築する補助的で便利なメソッドを提供するという課題に対処できますが、
+この章のはじめのほうで取り上げた他の2つの事例には対処できません：
+不変性の強制と自己参照オブジェクトの構築です。こういった課題には、内部コンストラクタメソッドが必要です。
+内部コンストラクタメソッドは、外部コンストラクタメソッドによく似ていますが、2つの違いがあります。
 
+1. これは型宣言のブロックの内部で宣言されていて、通常のメソッドのようにブロックの外部で宣言されていません。
+2. ブロックの宣言する型となるオブジェクトを作成する、ローカルで既存の特殊な関数`new`へのアクセスできます。
+
+
+
+```@raw html
+<!--
 For example, suppose one wants to declare a type that holds a pair of real numbers, subject to
 the constraint that the first number is not greater than the second one. One could declare it
 like this:
+-->
+```
+たとえば、一番目の数が二番目の数よりも大きくないという制約つきの、実数のペアを保持する型を宣言したいとします。
+この場合、次のように宣言することができます：
 
 ```jldoctest pairtype
 julia> struct OrderedPair
@@ -96,7 +176,15 @@ julia> struct OrderedPair
 
 ```
 
+
+```@raw html
+<!--
 Now `OrderedPair` objects can only be constructed such that `x <= y`:
+-->
+```
+
+ここで、`OrderedPair`オブジェクトは、`x <= y`を満たす場合だけ構成することができます。
+
 
 ```jldoctest pairtype
 julia> OrderedPair(1, 2)
@@ -108,6 +196,9 @@ Stacktrace:
  [1] OrderedPair(::Int64, ::Int64) at ./none:4
 ```
 
+
+```@raw html
+<!--
 If the type were declared `mutable`, you could reach in and directly change the field values to
 violate this invariant, but messing around with an object's internals uninvited is considered poor form.
 You (or someone else) can also provide additional outer constructor methods at any later point, but
@@ -116,12 +207,27 @@ methods can only create objects by calling other constructor methods, ultimately
 must be called to create an object. This guarantees that all objects of the declared type must come into
 existence by a call to one of the inner constructor methods provided with the type, thereby giving
 some degree of enforcement of a type's invariants.
+-->
+```
+型を`可変`に宣言すれば、フィールド値に直接アクセスして、不変性を破る変更ができますが、オブジェクトの内部で想定外のいじり方をするのはよくない手法です。
+あなた（または他の誰か）は後から外部コンストラクタメソッドを追加することはできますが、型を宣言した後で内部コンストラクタメソッドを追加することはできません。
+外部コンストラクタメソッドがオブジェクトを作成するには、他のコンストラクタメソッドを呼び出すしかないため、最終的には、内部コンストラクタのいづれかが必ず呼び出されてオブジェクトが作成されます。
+このため、型の宣言されたオブジェクトはすべて、その型に備わった内部コンストラクタメソッドの1つから生成されることが保証され、型の不変性がある程度強制されます。
 
+
+```@raw html
+<!--
 If any inner constructor method is defined, no default constructor method is provided: it is presumed
 that you have supplied yourself with all the inner constructors you need. The default constructor
 is equivalent to writing your own inner constructor method that takes all of the object's fields
 as parameters (constrained to be of the correct type, if the corresponding field has a type),
 and passes them to `new`, returning the resulting object:
+-->
+```
+内部コンストラクタメソッドが定義されている場合は、デフォルトのコンストラクタメソッドは生成されません。
+必要とするすべての内部コンストラクタはすべて自作することを前提としています。
+デフォルトのコンストラクタがすることは、次のような独自の内部コンストラクタメソッドを自作するのと同等です。
+その内部コンストラクタメソッドというのは、オブジェクトのすべてのフィールドを引数とし、（対応するフィールドに型を指定している場合は正しい型を設定し）、その引数を`new`に渡して、戻ってくるオブジェクト自身の戻り値とするような内部コンストラクタメソッドです。
 
 ```jldoctest
 julia> struct Foo
@@ -132,9 +238,18 @@ julia> struct Foo
 
 ```
 
+
+```@raw html
+<!--
 This declaration has the same effect as the earlier definition of the `Foo` type without an explicit
 inner constructor method. The following two types are equivalent -- one with a default constructor,
 the other with an explicit constructor:
+-->
+```
+
+この宣言は、`Foo`型の以前の定義で、明示的に内部コンストラクタメソッドを宣言していないものと同じ効果を持ちます。
+次の2つの型は同等です。一つはデフォルトのコンストラクタを使うもので、もう一つは明示的なコンストラクタをつかうものです。
+
 
 ```jldoctest
 julia> struct T1
@@ -159,17 +274,39 @@ julia> T2(1.0)
 T2(1)
 ```
 
+
+```@raw html
+<!--
 It is considered good form to provide as few inner constructor methods as possible: only those
 taking all arguments explicitly and enforcing essential error checking and transformation. Additional
 convenience constructor methods, supplying default values or auxiliary transformations, should
 be provided as outer constructors that call the inner constructors to do the heavy lifting. This
 separation is typically quite natural.
+-->
+```
 
-## Incomplete Initialization
+できるだけ内部コンストラクタメソッドを少なくするのは良い方法だと考えられています。
+そのメソッドは、すべての引数を明示的に取り、必須であるエラーチェックと変換を強制するものだけにします。
+デフォルト値や補助的な変換を提供する便利なコンストラクタメソッドを追加する時は、内部コンストラクタを呼び出す外部コンストラクタとして作成し、重い作業を行うようにすべきです。
+このように分離するのは、通常まったく自然なことです。
 
+
+
+[](## Incomplete Initialization)
+## 不完全な初期化
+
+
+```@raw html
+<!--
 The final problem which has still not been addressed is construction of self-referential objects,
 or more generally, recursive data structures. Since the fundamental difficulty may not be immediately
 obvious, let us briefly explain it. Consider the following recursive type declaration:
+-->
+```
+
+まだ説明していない最後の問題は、自己参照オブジェクト、さらに一般的には再帰的なデータ構造の生成です。
+根源的な難しさはすぐには分からないでしょうから、簡単に説明しましょう。次の再帰型宣言を考えてみましょう。
+
 
 ```jldoctest selfrefer
 julia> mutable struct SelfReferential
@@ -178,24 +315,52 @@ julia> mutable struct SelfReferential
 
 ```
 
+
+```@raw html
+<!--
 This type may appear innocuous enough, until one considers how to construct an instance of it.
 If `a` is an instance of `SelfReferential`, then a second instance can be created by the call:
+-->
+```
+
+この型は、どうやってインスタンス化するかを考えなければ、問題ないように見えるかもしれません。
+`a`という`SelfReferential`のインスタンスがあれば、呼び出しによって2つ目のインスタンスを作成できます。
+
 
 ```julia-repl
 julia> b = SelfReferential(a)
 ```
 
+
+```@raw html
+<!--
 But how does one construct the first instance when no instance exists to provide as a valid value
 for its `obj` field? The only solution is to allow creating an incompletely initialized instance
 of `SelfReferential` with an unassigned `obj` field, and using that incomplete instance as a valid
 value for the `obj` field of another instance, such as, for example, itself.
+-->
+```
+しかし、`obj`フィールドに使う有効な値のインスタンスがなければ、最初のインスタンスはどうやって作成するのでしょうか？
+唯一の解決法は、`obj`フィールドに、なにも代入されていない初期化の不完全な`SelfReferential`のインスタンスを作成し、その不完全なインスタンスを`obj`フィールドの有効な値として別のインスタンス(例えば自分自身)に使うという方法です。
 
+
+
+```@raw html
+<!--
 To allow for the creation of incompletely initialized objects, Julia allows the `new` function
 to be called with fewer than the number of fields that the type has, returning an object with
 the unspecified fields uninitialized. The inner constructor method can then use the incomplete
 object, finishing its initialization before returning it. Here, for example, we take another crack
 at defining the `SelfReferential` type, with a zero-argument inner constructor returning instances
 having `obj` fields pointing to themselves:
+-->
+```
+初期化が不完全でもオブジェクトを作成できるように、Juliaでは、引数が型のフィールド数より少なくても`new`関数を呼び出すことができます。
+この`new`関数は、未指定のフィールドは初期化しないままで、オブジェクトを返します。
+そのため、内部コンストラクタメソッドは不完全なオブジェクトを利用でき、オブジェクトを返す前に初期化を完了します。
+ここで、`SelfReferential`型の別の例を挙げてみましょう。
+この例では、引数のない内部コンストラクタが、`obj`フィールドが自身を指すインスタンスを返します。
+
 
 ```jldoctest selfrefer2
 julia> mutable struct SelfReferential
@@ -205,7 +370,14 @@ julia> mutable struct SelfReferential
 
 ```
 
+
+```@raw html
+<!--
 We can verify that this constructor works and constructs objects that are, in fact, self-referential:
+-->
+```
+このコンストラクタが実際に動作して、自己参照型のオブジェクトを作成することを、検証できます。
+
 
 ```jldoctest selfrefer2
 julia> x = SelfReferential();
@@ -220,8 +392,15 @@ julia> x === x.obj.obj
 true
 ```
 
+
+```@raw html
+<!--
 Although it is generally a good idea to return a fully initialized object from an inner constructor,
 incompletely initialized objects can be returned:
+-->
+```
+内部コンストラクタが完全に初期化されたオブジェクトを返す方が通常は良い手法ですが、初期化の不完全なオブジェクトを返すこともできます。
+
 
 ```jldoctest incomplete
 julia> mutable struct Incomplete
@@ -232,19 +411,38 @@ julia> mutable struct Incomplete
 julia> z = Incomplete();
 ```
 
+
+```@raw html
+<!--
 While you are allowed to create objects with uninitialized fields, any access to an uninitialized
 reference is an immediate error:
+-->
+```
+初期化されていないフィールドを持つオブジェクトを作成することはできますが、初期化されていない参照にアクセスすると、即座にエラーが生じます。
 
 ```jldoctest incomplete
 julia> z.xx
 ERROR: UndefRefError: access to undefined reference
 ```
 
+
+```@raw html
+<!--
 This avoids the need to continually check for `null` values. However, not all object fields are
 references. Julia considers some types to be "plain data", meaning all of their data is self-contained
 and does not reference other objects. The plain data types consist of primitive types (e.g. `Int`)
 and immutable structs of other plain data types. The initial contents of a plain data type is
 undefined:
+-->
+```
+
+このため、`null`値を継続的にチェックする必要がなくなります。
+ただし、すべてのオブジェクトフィールドが参照であるとは限りません。
+Juliaは、いくつかの型を「プレーンデータ」とみなします。
+「プレーンデータ」とは、すべてのデータが自身に含まれ、他のオブジェクトを参照していないことを意味します。
+プレーンデータ型には、原始型（`Int`など）や、他のプレーンデータ型から成る不変な複合型があります。
+プレーンなデータ型は、初期状態ではの内容が定義されていません。
+
 
 ```julia-repl
 julia> struct HasPlain
@@ -256,9 +454,18 @@ julia> HasPlain()
 HasPlain(438103441441)
 ```
 
+
+```@raw html
+<!--
 Arrays of plain data types exhibit the same behavior.
 
 You can pass incomplete objects to other functions from inner constructors to delegate their completion:
+-->
+```
+プレーンデータ型の配列は同様な動作をします。
+
+不完全なオブジェクトを内部コンストラクタから他の関数​​に渡して、完成を委譲することができます。
+
 
 ```jldoctest
 julia> mutable struct Lazy
@@ -267,16 +474,33 @@ julia> mutable struct Lazy
        end
 ```
 
+
+```@raw html
+<!--
 As with incomplete objects returned from constructors, if `complete_me` or any of its callees
 try to access the `xx` field of the `Lazy` object before it has been initialized, an error will
 be thrown immediately.
+-->
+```
+コンストラクタから返される不完全なオブジェクトと同じように、`complete_me`など呼び出し先が初期化する前に`Lazy`オブジェクトの`xx`フィールドにアクセスしようとすると、即座にエラーが投げられます。
 
-## Parametric Constructors
+[](## Parametric Constructors)
+## パラメトリックコンストラクタ
 
+
+```@raw html
+<!--
 Parametric types add a few wrinkles to the constructor story. Recall from [Parametric Types](@ref)
 that, by default, instances of parametric composite types can be constructed either with explicitly
 given type parameters or with type parameters implied by the types of the arguments given to the
 constructor. Here are some examples:
+-->
+```
+パラメトリック型の場合は、今までのコンストラクタの話に新たな面が加わります。
+[パラメトリック型](@ref) のことを復習しましょう。
+デフォルトでは、パラメトリック複合型をインスタンス化する際の型の指定は、明示的に型パラメータを使う方法と、引数から暗黙的に推論させる方法があります。
+いくつか例を示します。
+
 
 ```jldoctest parametric
 julia> struct Point{T<:Real}
@@ -311,13 +535,26 @@ julia> Point{Float64}(1,2) ## explicit T ##
 Point{Float64}(1.0, 2.0)
 ```
 
+
+```@raw html
+<!--
 As you can see, for constructor calls with explicit type parameters, the arguments are converted
 to the implied field types: `Point{Int64}(1,2)` works, but `Point{Int64}(1.0,2.5)` raises an
 [`InexactError`](@ref) when converting `2.5` to [`Int64`](@ref). When the type is implied
 by the arguments to the constructor call, as in `Point(1,2)`, then the types of the
 arguments must agree -- otherwise the `T` cannot be determined -- but any pair of real
 arguments with matching type may be given to the generic `Point` constructor.
+-->
+```
+御覧のように、明示的に型パラメータを指定してコンストラクタを呼び出すと、引数は暗黙的にフィールドの型に変換されます。
+`Point{Int64}(1,2)`とすると動作しますが、`Point{Int64}(1.0,2.5)`とすると、 `2.5` を [`Int64`](@ref) に変換する際に、
+[`InexactError`](@ref) が発生します。
+`Point(1,2)`のように、コンストラクタ呼び出しの引数によって、型が暗黙的に指定されている場合、引数の型どうしは一致させる必要があります。でなければ、`T`を決定できません。任意の実引数のペアは、型が一致していれば、汎化`Point`コンストラクタに渡すことができます。
 
+`
+
+```@raw html
+<!--
 What's really going on here is that `Point`, `Point{Float64}` and `Point{Int64}` are all different
 constructor functions. In fact, `Point{T}` is a distinct constructor function for each type `T`.
 Without any explicitly provided inner constructors, the declaration of the composite type `Point{T<:Real}`
@@ -325,6 +562,14 @@ automatically provides an inner constructor, `Point{T}`, for each possible type 
 behaves just like non-parametric default inner constructors do. It also provides a single general
 outer `Point` constructor that takes pairs of real arguments, which must be of the same type.
 This automatic provision of constructors is equivalent to the following explicit declaration:
+-->
+```
+
+ここで見てきたことは、`Point`、`Point{Float64}`、`Point{Int64}`すべてが異なるコンストラクタ関数だということです。
+実際、`Point{T}`は、型`T`ごとにそれぞれ異なるコンストラクタ関数があります。
+明示的に内部コンストラクタを定義しない場合は、複合型の宣言`Point{T<:Real}`は 、`T<:Real`を満たすそれぞれの型に対して、自動的に内部コンストラクタ`Point{T}`を生成し、パラメータを使わないデフォルトの内部コンストラクタのように振る舞います。
+こうしたコンストラクタの自動生成は、以下の明示的な宣言と同等です。
+
 
 ```jldoctest parametric2
 julia> struct Point{T<:Real}
@@ -336,6 +581,9 @@ julia> struct Point{T<:Real}
 julia> Point(x::T, y::T) where {T<:Real} = Point{T}(x,y);
 ```
 
+
+```@raw html
+<!--
 Notice that each definition looks like the form of constructor call that it handles.
 The call `Point{Int64}(1,2)` will invoke the definition `Point{T}(x,y)` inside the
 `type` block.
@@ -345,19 +593,43 @@ type. This declaration makes constructor calls without explicit type parameters,
 and `Point(1.0,2.5)`, work. Since the method declaration restricts the arguments to being of the
 same type, calls like `Point(1,2.5)`, with arguments of different types, result in "no method"
 errors.
+-->
+```
+各コンストラクタの定義と呼び出しは、同じような形式であることに注意してください。
+`Point{Int64}(1,2)`のように呼び出すと、`型`ブロック内の定義`Point{T}(x,y)`が呼び出されます。
+一方、外部コンストラクタの宣言では、実数の同じ型の組にのみ適用される汎化コンストラクタ`Point`のメソッドが定義されています。
+この宣言によって、`Point(1,2)` や`Point(1.0,2.5)`のように明示的に型パラメータをつけないコンストラクタの呼び出しが可能になります。
+このメソッドの宣言では、引数が同じ型のものに制限されるため、`Point(1,2.5)`のような異なる型の引数を持つ呼び出しは、 "no method"のエラーがおこします。
 
+
+
+```@raw html
+<!--
 Suppose we wanted to make the constructor call `Point(1,2.5)` work by "promoting" the integer
 value `1` to the floating-point value `1.0`. The simplest way to achieve this is to define the
 following additional outer constructor method:
+-->
+```
+`Point(1,2.5)`のようにコンストラクタを呼び出す時、整数値`1`を浮動小数点値`1.0`に「昇格」させたいとします。
+これを実現する最も簡単な方法は、以下のように外部コンストラクタメソッドの定義を追加することです。
+
 
 ```jldoctest parametric2
 julia> Point(x::Int64, y::Float64) = Point(convert(Float64,x),y);
 ```
 
+
+```@raw html
+<!--
 This method uses the [`convert()`](@ref) function to explicitly convert `x` to [`Float64`](@ref)
 and then delegates construction to the general constructor for the case where both arguments are
 [`Float64`](@ref). With this method definition what was previously a [`MethodError`](@ref) now
 successfully creates a point of type `Point{Float64}`:
+-->
+```
+このメソッドは、[`convert()`](@ref)関数を使用して、`x` を [`Float64`](@ref) に変換し、両方の引数が[`Float64`](@ref)の時に使用できる汎化コンストラクタに委譲します。
+こうして、以前は[`MethodError`](@ref)の生じたメソッド定義から、`Point{Float64}`型の値を正常に作成できるようになりました。
+
 
 ```jldoctest parametric2
 julia> Point(1,2.5)
@@ -367,7 +639,14 @@ julia> typeof(ans)
 Point{Float64}
 ```
 
+
+```@raw html
+<!--
 However, other similar calls still don't work:
+-->
+```
+しかし、他の似たような呼び出しはまだ動作しません。
+
 
 ```jldoctest parametric2
 julia> Point(1.5,2)
@@ -376,17 +655,33 @@ Closest candidates are:
   Point(::T<:Real, !Matched::T<:Real) where T<:Real at none:1
 ```
 
+
+```@raw html
+<!--
 For a more general way to make all such calls work sensibly, see [Conversion and Promotion](@ref conversion-and-promotion).
 At the risk of spoiling the suspense, we can reveal here that all it takes is the following outer
 method definition to make all calls to the general `Point` constructor work as one would expect:
+-->
+```
+このような呼び出しをうまく動作させる一般的な方法については、[変換と昇格]（@ ref conversion-and-promotion）を参照してください。
+今までの話が無駄になるかもしれませんが、白状してしまうと、汎化コンストラクタ`Point`を様々な引数に対して期待どおりに動作させるには、外部メソッドの定義を以下のようにすればいいのです。
+
 
 ```jldoctest parametric2
 julia> Point(x::Real, y::Real) = Point(promote(x,y)...);
 ```
 
+
+```@raw html
+<!--
 The `promote` function converts all its arguments to a common type -- in this case [`Float64`](@ref).
 With this method definition, the `Point` constructor promotes its arguments the same way that
 numeric operators like [`+`](@ref) do, and works for all kinds of real numbers:
+-->
+```
+この`promote`関数はすべての引数を共通の型、この場合は [`Float64`](@ref)に変換します。
+このようにメソッドを定義すると、`Point`コンストラクタは、算術演算子の [`+`](@ref)と同じように引数を昇格するので、あらゆる種類の実数に対して動作します。
+
 
 ```jldoctest parametric2
 julia> Point(1.5,2)
@@ -399,16 +694,33 @@ julia> Point(1.0,1//2)
 Point{Float64}(1.0, 0.5)
 ```
 
+
+```@raw html
+<!--
 Thus, while the implicit type parameter constructors provided by default in Julia are fairly strict,
 it is possible to make them behave in a more relaxed but sensible manner quite easily. Moreover,
 since constructors can leverage all of the power of the type system, methods, and multiple dispatch,
 defining sophisticated behavior is typically quite simple.
+-->
+```
+したがって、デフォルトではJuliaの型パラメータコンストラクタの暗黙的な型の扱いはかなり厳格ですが、それらをより気軽で、しかし理にかなった方法で動作させることが可能です。
+さらに、コンストラクタは型システム、メソッド、および多重ディスパッチのすべての機能を活用できるため、洗練された動作を定義するのは通常は非常に簡単です。
 
-## Case Study: Rational
+[](## Case Study: Rational)
+## 事例研究: 有理数
 
+
+
+```@raw html
+<!--
 Perhaps the best way to tie all these pieces together is to present a real world example of a
 parametric composite type and its constructor methods. To that end, here is the (slightly modified) beginning of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
 which implements Julia's [有理数](@ref):
+-->
+```
+おそらく、これらの要素すべてを結びつける最良の方法は、パラメトリック複合型とそのコンストラクタメソッドの実例を見てみることです。
+そこで、 [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)　の始めの方でJuliaの[有理数](@ref)を実装している部分を（少し修正していますが）見てみましょう。
+
 
 ```jldoctest rational
 julia> struct OurRational{T<:Integer} <: Real
@@ -457,11 +769,22 @@ julia> function //(x::Complex, y::Complex)
 // (generic function with 6 methods)
 ```
 
+
+```@raw html
+<!--
 The first line -- `struct OurRational{T<:Integer} <: Real` -- declares that `OurRational` takes one
 type parameter of an integer type, and is itself a real type. The field declarations `num::T`
 and `den::T` indicate that the data held in a `OurRational{T}` object are a pair of integers of type
 `T`, one representing the rational value's numerator and the other representing its denominator.
+-->
+```
+最初の行 の`struct OurRational{T<:Integer} <: Real` では、`OurRational`という型は、整数型の型パラメータ1個をとり、自身は実数型であることを宣言しています。
+フィールドの宣言である`num::T` と`den::T`は、`OurRational{T}`オブジェクトには整数型`T`のペアが保持されていて、これが有理数の分子と分母のペアを表していることを示しています。
 
+
+
+```@raw html
+<!--
 Now things get interesting. `OurRational` has a single inner constructor method which checks that
 both of `num` and `den` aren't zero and ensures that every rational is constructed in "lowest
 terms" with a non-negative denominator. This is accomplished by dividing the given numerator and
@@ -470,14 +793,37 @@ denominator values by their greatest common divisor, computed using the `gcd` fu
 (`den` here), after this division the new value of `den` is guaranteed to be non-negative. Because
 this is the only inner constructor for `OurRational`, we can be certain that `OurRational` objects are
 always constructed in this normalized form.
+-->
+```
+面白くなってきました。
+`OurRational`には内部コンストラクタメソッドが1つあって、`num`と`den`の両方が0ではないことを検査し、すべての有理数が、分母が非負の「既約分数」で構成されることを保証します。
+これは、与えられた分子と分母の値を、最大公約数で割ることで得られ、最大公約数は`gcd`関数を使って計算されます。
+`gcd`関数は、引数の最大公約数を最初の引数（ここでは`den`）に一致する符号で返すため、
+割り算の後に得られる新しい`den`の値は非負であることが保証されます。
+これは`OurRational`の唯一の内部コンストラクタであるため、`OurRational`オブジェクトは常にこうした正規化された形式で構築されていると断言できます。
 
+
+
+```@raw html
+<!--
 `OurRational` also provides several outer constructor methods for convenience. The first is the "standard"
 general constructor that infers the type parameter `T` from the type of the numerator and denominator
 when they have the same type. The second applies when the given numerator and denominator values
 have different types: it promotes them to a common type and then delegates construction to the
 outer constructor for arguments of matching type. The third outer constructor turns integer values
 into rationals by supplying a value of `1` as the denominator.
+-->
+```
+`OurRational`には便宜のため、いくつかの外部コンストラクタメソッドも備わっています。
+一つ目は、分子と分母の型が同じ場合、その型から型パラメータ`T`を推論する「標準」汎化コンストラクタです。
+二つ目は、与えられた分子と分母の値の型が異なる場合に適用されます。
+それらを共通の型に昇格させ、その後、型の一致する引数に対して動作する外部コンストラクタに生成を委譲します。
+三つ目の外部コンストラクタは、分母に値`1`を与えて整数値を有理数に変換します。
 
+
+
+```@raw html
+<!--
 Following the outer constructor definitions, we have a number of methods for the [`//`](@ref)
 operator, which provides a syntax for writing rationals. Before these definitions, [`//`](@ref)
 is a completely undefined operator with only syntax and no meaning. Afterwards, it behaves just
@@ -489,6 +835,16 @@ this behavior is actually identical to division of a rational with an integer.
 Finally, applying
 [`//`](@ref) to complex integral values creates an instance of `Complex{OurRational}` -- a complex
 number whose real and imaginary parts are rationals:
+-->
+```
+外部コンストラクタの定義に続いては、[`//`](@ref) 演算子のための多数のメソッドがあります。これは、有理数を書くための構文です。
+こういった定義がなければ、[`//`](@ref) は、構文だけで完全に意味のない未定義の演算子です。
+定義をすると、 [有理数](@ref)で説明したような動作をします。その動作は全て、このファイルの数行で定義されています。
+第一の、そして最も基本的な定義では、`a`と`b`が整数の時に、`OurRational`コンストラクタを適用して`a//b`を生成します。
+ [`//`](@ref)の被演算子の1つが既に有理数である場合、新しい有理数は比の結果として少し違う方法で生成されます。
+この動作は実際には有理数と整数の除算と同一です。
+最後に、 [`//`](@ref)を複素有理数に適用して、`Complex{OurRational}`のインスタンスを作成します。
+これは実部と虚部が有理数である複素数をあらわします。
 
 ```jldoctest rational
 julia> ans = (1 + 2im)//(1 - 2im);
@@ -500,45 +856,107 @@ julia> ans <: Complex{OurRational}
 false
 ```
 
+
+```@raw html
+<!--
 Thus, although the [`//`](@ref) operator usually returns an instance of `OurRational`, if either
 of its arguments are complex integers, it will return an instance of `Complex{OurRational}` instead.
 The interested reader should consider perusing the rest of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl):
 it is short, self-contained, and implements an entire basic Julia type.
+-->
+```
+したがって、[`//`](@ref)演算子は通常`OurRational`のインスタンスを返しますが、引数のいずれかが複素数の場合、替わりに`Complex{OurRational}`のインスタンスを返します。
+興味のある読者は、[`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)の残りの部分を熟読するといいでしょう。
+短くてファイル内で完結していますが、Juliaの基本的な型である有理数型全体が実装されています。
 
-## [Constructors and Conversion](@id constructors-and-conversion)
+[](## [Constructors and Conversion](@id constructors-and-conversion))
+## [コンストラクタと変換](@id constructors-and-conversion)
 
+
+```@raw html
+<!--
 Constructors `T(args...)` in Julia are implemented like other callable objects: methods are added
 to their types. The type of a type is `Type`, so all constructor methods are stored in the method
-table for the `Type` type. This means that you can declare more flexible constructors, e.g. constructors
+table for the `Type` type. This mans that you can declare more flexible constructors, e.g. constructors
 for abstract types, by explicitly defining methods for the appropriate types.
+-->
+```
+Juliaでは、`T(args...)`というコンストラクタは、他の呼び出し可能なオブジェクトと同じように実装されています。つまり型に対してメソッドが付加されています。
+型の型は`Type`であり、すべてのコンストラクタのメソッドは`Type`型のメソッド・テーブルに格納されます。
+そのため、適切な型に対してメソッドを明示的に定義すると、抽象型のコンストラクタなど、より柔軟にコンストラクタを宣言することができます。
 
+```@raw html
+<!--
 However, in some cases you could consider adding methods to `Base.convert` *instead* of defining
 a constructor, because Julia falls back to calling [`convert()`](@ref) if no matching constructor
 is found. For example, if no constructor `T(args...) = ...` exists `Base.convert(::Type{T}, args...) = ...`
 is called.
+-->
+```
+ただし、コンストラクタを定義する** 替わりに**、`Base.convert`メソッドを追加したほうがいい場合もあります。
+Juliaでは、適切なコンストラクタが見つからない場合には、[`convert()`](@ref) が呼ばれるからです。
+たとえば、`T(args...) = ...`というコンストラクタが存在しない場合は、`Base.convert(::Type{T}, args...) = ...` が呼び出されます。
 
+
+
+```@raw html
+<!--
 `convert` is used extensively throughout Julia whenever one type needs to be converted to another
 (e.g. in assignment, [`ccall`](@ref), etcetera), and should generally only be defined (or successful)
 if the conversion is lossless.  For example, `convert(Int, 3.0)` produces `3`, but `convert(Int, 3.2)`
 throws an `InexactError`.  If you want to define a constructor for a lossless conversion from
 one type to another, you should probably define a `convert` method instead.
+-->
+```
+`convert`はあるタイプを別のタイプに変換する必要があるとき（たとえば、代入や[`ccall`](@ref)など）、Julia全体で広範囲に使用されます。
+通常は、`convert`は変換が可逆の時にのみ定義すべきで、うまくいくのもそうした時のみでしょう。
+たとえば、`convert(Int, 3.0)`は`3`を生成しますが、`convert(Int, 3.2)`は `InexactError`を投げます。
+あるタイプから別のタイプへの可逆変換をするコンストラクタを定義したい場合は、おそらく`convert`メソッドを定義すべきでしょう。
 
+
+
+```@raw html
+<!--
 On the other hand, if your constructor does not represent a lossless conversion, or doesn't represent
 "conversion" at all, it is better to leave it as a constructor rather than a `convert` method.
 For example, the `Array{Int}()` constructor creates a zero-dimensional `Array` of the type `Int`,
 but is not really a "conversion" from `Int` to an `Array`.
+-->
+```
+一方、コンストラクタが可逆変換ではない場合、または「変換」を表していない場合は、`convert`メソッドではなくコンストラクタのままにしたほうががよいでしょう。
+例えば、`Array{Int}()`コンストラクタは、ゼロ次元の`Int`型の`Array`を生成します。しかしこれはまったく、`Int`から`Array`への「変換」ではありません。
 
-## Outer-only constructors
+[](## Outer-only constructors)
 
+## 外部限定コンストラクタ
+
+
+```@raw html
+<!--
 As we have seen, a typical parametric type has inner constructors that are called when type parameters
 are known; e.g. they apply to `Point{Int}` but not to `Point`. Optionally, outer constructors
 that determine type parameters automatically can be added, for example constructing a `Point{Int}`
 from the call `Point(1,2)`. Outer constructors call inner constructors to do the core work of
 making an instance. However, in some cases one would rather not provide inner constructors, so
 that specific type parameters cannot be requested manually.
+-->
+```
+これまで見てきたように、一般的なパラメトリック型には、型パラメータが既知のときに呼び出される内部コンストラクタがあります。
+例えば、`Point`ではなく`Point{Int}`が適用されます。
+必要に応じて、型パラメータを自動的に決定する外部コンストラクタを追加することができます。例えば、`Point(1,2)`から`Point{Int}`を呼び出すことができます。
+外部のコンストラクタは内部のコンストラクタを呼び出して、インスタンスを作成する中核的な作業を行います。
+しかし、特定の型パラメータを手動で呼び出せないように、内部コンストラクタを提供したくない場合もあります。
 
+
+
+```@raw html
+<!--
 For example, say we define a type that stores a vector along with an accurate representation of
 its sum:
+-->
+```
+たとえば、ベクトルを格納し、さらにその合計を正確に表現する型を定義するとします。
+
 
 ```jldoctest
 julia> struct SummedArray{T<:Number,S<:Number}
@@ -550,12 +968,22 @@ julia> SummedArray(Int32[1; 2; 3], Int32(6))
 SummedArray{Int32,Int32}(Int32[1, 2, 3], 6)
 ```
 
+
+```@raw html
+<!--
 The problem is that we want `S` to be a larger type than `T`, so that we can sum many elements
 with less information loss. For example, when `T` is [`Int32`](@ref), we would like `S` to
 be [`Int64`](@ref). Therefore we want to avoid an interface that allows the user to construct
 instances of the type `SummedArray{Int32,Int32}`. One way to do this is to provide a
 constructor only for `SummedArray`, but inside the `type` definition block to suppress
 generation of default constructors:
+-->
+```
+ここで問題は、`S`を`T`より大きな型にして、多くの要素の合計を求める際に情報損失を少なくしたいということです。
+たとえば、`T` を[`Int32`](@ref)、`S`を [`Int64`](@ref)とします。
+そして、ユーザーが`SummedArray{Int32,Int32}`といった型のインスタンスを構築できるようなインターフェイスは避けたいと考えています。
+これを行う方法の1つは、`SummedArray`コンストラクタの提供のみを行い、`型`定義ブロックの中でデフォルトのコンストラクタの生成を抑止することです。
+
 
 ```jldoctest
 julia> struct SummedArray{T<:Number,S<:Number}
@@ -573,7 +1001,16 @@ Closest candidates are:
   SummedArray(::Array{T,1}) where T at none:5
 ```
 
+
+```@raw html
+<!--
 This constructor will be invoked by the syntax `SummedArray(a)`. The syntax `new{T,S}` allows
 specifying parameters for the type to be constructed, i.e. this call will return a `SummedArray{T,S}`.
 `new{T,S}` can be used in any constructor definition, but for convenience the parameters
 to `new{}` are automatically derived from the type being constructed when possible.
+-->
+```
+このコンストラクタは`SummedArray(a)`という構文によって呼び出されます。
+`new{T,S}`という構文で、構築する型のパラメータを指定できます。
+つまり、この呼び出しは`SummedArray{T,S}`を返します。
+ `new{T,S}`を任意のコンストラクタ定義で使用することができますが、便宜のため、`new{}`に対するパラメータは、可能な場合は、生成される型から自動的に推定されます。

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -1243,7 +1243,7 @@ end
 The `catch` clause is not strictly necessary; when omitted, the default return value is `nothing`.
 -->
 ```
-この`catch`節は厳密には必要ではありません。省略された場合、デフォルトの戻り値は`nothing`です。
+この`catch`節は必ずしも必要ではありません。省略された場合、デフォルトの戻り値は`nothing`です。
 
 
 ```jldoctest
@@ -1259,7 +1259,7 @@ is desirable. Julia provides the [`rethrow()`](@ref), [`backtrace()`](@ref) and 
 functions for more advanced error handling.
 -->
 ```
-`try/catch`文が強力なのは、深く入れ子になった計算から、関数呼び出しを重ねたはるかに高いレベルまで、飛び越えて戻ることができることにあります。エラーが発生していない場合でも、スタックを飛び越えて戻ってより高いレベルに値を渡す機能はほしいものです。
+`try/catch`文が強力なのは、深くネストした計算から、関数呼び出しを重ねたはるかに高いレベルまで、飛び越えて戻ることができることにあります。エラーが発生していない場合でも、スタックを飛び越えて戻ってより高いレベルに値を渡す機能はほしいものです。
 Juliaでは [`rethrow()`](@ref), [`backtrace()`](@ref) and [`catch_backtrace()`](@ref) といった さらに高度なエラー処理のための関数が用意されています。
 
 [](### `finally` Clauses)

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -1,12 +1,24 @@
-# [Conversion and Promotion](@id conversion-and-promotion)
+[](# [Conversion and Promotion](@id conversion-and-promotion))
+# [変換と昇格](@id conversion-and-promotion)
 
+
+
+```@raw html
+<!--
 Julia has a system for promoting arguments of mathematical operators to a common type, which has
 been mentioned in various other sections, including [整数と浮動小数点数](@ref),
 [算術処理と基本的な関数](@ref), [Types](@ref man-types), and [Methods](@ref).
 In this section, we explain how this promotion system works, as well as how to extend it to new
 types and apply it to functions besides built-in mathematical operators. Traditionally, programming
 languages fall into two camps with respect to promotion of arithmetic arguments:
+-->
+```
+Juliaには、[整数と浮動小数点数](@ref)、[算術処理と基本的な関数] (@ref)、[型]（@ ref man-types）、[メソッド](@ref)、その他のさまざまな章に記述されているように、算術演算子の引数を共通の型に昇格するシステムが備わっています。
+この章では、この昇格システムが動作するしくみや、昇格システムを新しい型に拡張して標準装備の算術演算子や関数でも動作させる方法について説明します。通常、プログラミング言語は算術演算の引数がどのように昇格するかによって、2つの陣営に分類されています。
 
+ 
+ ```@raw html
+ <!--
   * **Automatic promotion for built-in arithmetic types and operators.** In most languages, built-in
     numeric types, when used as operands to arithmetic operators with infix syntax, such as `+`,
     `-`, `*`, and `/`, are automatically promoted to a common type to produce the expected results.
@@ -17,7 +29,14 @@ languages fall into two camps with respect to promotion of arithmetic arguments:
     compilers and interpreters must perform conversion before addition since integers and floating-point
     values cannot be added as-is. Complex rules for such automatic conversions are thus inevitably
     part of specifications and implementations for such languages.
-  * **No automatic promotion.** This camp includes Ada and ML -- very "strict" statically typed languages.
+-->
+ ```
+ *  **標準装備の算術型と演算子の自動昇格** ほとんどの言語では、標準装備の数値型が、`+`、 `-`、`*`、`/`などの中置記法の算術演算子の被演算子として使われるときは、自動的に共通の型に昇格してから、演算結果が生成されます。少し例を挙げると、 C、Java、Perl、Pythonなどはすべて、`1 + 1.5`の合計を、浮動小数点値の`2.5`として正しく計算することができますが、`+`の被演算子の一方は整数です。こういうシステムは便利であり、通常はプログラマにはまったく見えないように慎重に設計されています。このような式を書くときに昇格が起こっていると意識する人はほとんどいませんが、コンパイラやインタプリタは、足し算を行う前に変換を必ずおこないます。整数と浮動小数点数はそのままでは足せないからです。このような自動変換の複雑な規則は、必然的にこの陣営の言語では仕様や実装の一部となります。
+
+ 
+ ```@raw html
+ <!--
+   * **No automatic promotion.** This camp includes Ada and ML -- very "strict" statically typed languages.
     In these languages, every conversion must be explicitly specified by the programmer. Thus, the
     example expression `1 + 1.5` would be a compilation error in both Ada and ML. Instead one must
     write `real(1) + 1.5`, explicitly converting the integer `1` to a floating-point value before
@@ -25,7 +44,14 @@ languages fall into two camps with respect to promotion of arithmetic arguments:
     has some degree of automatic conversion: integer literals are promoted to the expected integer
     type automatically, and floating-point literals are similarly promoted to appropriate floating-point
     types.
+-->
+ ```
+   * **非自動昇格**この陣営にはAdaとMLなどの非常に「厳密」な静的に型付けされた言語があります。こういった言語では、すべての変換をプログラマが明示的に指定する必要があります。したがって、例に挙げた`1 + 1.5`という式は、AdaやMLでは共にコンパイルエラーになります。これを避けるには`real(1) + 1.5`のように書いて、足し算を実行する前に整数`1`を浮動小数点数に明示的に変換する必要があります。しかし、常に明示的に変換しなければならないのは不便なので、Adaでさえもある程度の自動変換が行われます。整数リテラルは期待されるように整数型に自動的に昇格され、浮動小数点リテラルも同様に適切な浮動小数点型に昇格されます。
 
+
+
+```@raw html
+<!--
 In a sense, Julia falls into the "no automatic promotion" category: mathematical operators are
 just functions with special syntax, and the arguments of functions are never automatically converted.
 However, one may observe that applying mathematical operations to a wide variety of mixed argument
@@ -38,13 +64,34 @@ promotion rules, and then invoke a specialized implementation of the operator in
 the resulting values, now of the same type. User-defined types can easily participate in this
 promotion system by defining methods for conversion to and from other types, and providing a handful
 of promotion rules defining what types they should promote to when mixed with other types.
+-->
+```
 
-## Conversion
+Juliaでは、算術演算子は特殊な構文を持つ関数に過ぎず、関数の引数は決して自動的に変換されません。
+その意味では、Juliaは「非自動昇格」の陣営に分類されるでしょう。
+しかし、様々な型の混合した引数に算術演算を適用することは、多相的な多重ディスパッチの極端な事例に過ぎません。これは型によるディスパッチをおこなうJuliaのシステムに非常に適しています。
+算術演算における被演算子の「自動」昇格は、特殊な適用がおきただけです。Juliaには、算術演算子を全捕捉するディスパッチ規則が事前に定義されており、被演算子の型の組み合わせに対して特化した実装が存在しないときに呼び出されます。
+この全捕捉規則は、まずユーザーが定義できる昇格規則を利用してすべての被演算子を共通の型に昇格し、こうして同一の型となった演算結果の型に特化した演算子の実装を呼び出します。
+ユーザーの定義した型もこの昇格システムに簡単に追加できます。
+ユーザー定義型に対して、他の型との変換メソッドを相互に定義し、他の型が混在する場合にどの型に昇格するかを定義する少数の昇格規則を決めてやればいいのです。
 
+[](## Conversion)
+## 変換
+
+
+```@raw html
+<!--
 Conversion of values to various types is performed by the `convert` function. The `convert` function
 generally takes two arguments: the first is a type object while the second is a value to convert
 to that type; the returned value is the value converted to an instance of given type. The simplest
 way to understand this function is to see it in action:
+-->
+```
+値をさまざまな型に変換するのは、`convert`関数です。
+この`convert`関数は通常、2つの引数をとります。1番目は型オブジェクトで、2番目はその型に変換される値です。
+戻り値は指定された型のインスタンスに変換された値です。
+この関数を理解する最も簡単な方法は、実際の動作を確認することです。
+
 
 ```jldoctest
 julia> x = 12
@@ -76,8 +123,14 @@ julia> convert(Array{Float64}, a)
  4.0  5.0  6.0
 ```
 
+
+```@raw html
+<!--
 Conversion isn't always possible, in which case a no method error is thrown indicating that `convert`
 doesn't know how to perform the requested conversion:
+-->
+```
+変換は常に可能であるとは限りません。そんな時は、ノーメソッドエラーが投げられて、`convert`関数は要求された変換の実行方法を知らないことを通知します。
 
 ```jldoctest
 julia> convert(AbstractFloat, "foo")
@@ -86,21 +139,40 @@ This may have arisen from a call to the constructor AbstractFloat(...),
 since type constructors fall back to convert methods.
 ```
 
+
+```@raw html
+<!--
 Some languages consider parsing strings as numbers or formatting numbers as strings to be conversions
 (many dynamic languages will even perform conversion for you automatically), however Julia does
 not: even though some strings can be parsed as numbers, most strings are not valid representations
 of numbers, and only a very limited subset of them are. Therefore in Julia the dedicated `parse()`
 function must be used to perform this operation, making it more explicit.
+-->
+```
+言語の中には文字列を解析して数値とみなしたり、書式付きの数値を変換して文字列とみなしたりするものがありますが、（多くの動的言語では自動的に変換が行われます）、Juliaはそうではありません。文字列の中には数値として解析できるものもありますが、ほとんどの文字列は数値としては妥当な表現ではなく、非常に限られた一部のみです。そのため、Juliaでは、こういった操作は、専用の関数`parse()` を使って明示的に行う必要があります。
 
-### Defining New Conversions
+[](### Defining New Conversions)
+### 新しい変換の定義
 
+
+```@raw html
+<!--
 To define a new conversion, simply provide a new method for `convert()`. That's really all there
 is to it. For example, the method to convert a real number to a boolean is this:
+-->
+```
+
+新しく変換を定義するには、`convert()`に新たなメソッドを加えるだけです。それがすべてです。たとえば、実数をブール値に変換するメソッドは次のとおりです。
+
+
 
 ```julia
 convert(::Type{Bool}, x::Real) = x==0 ? false : x==1 ? true : throw(InexactError())
 ```
 
+
+```@raw html
+<!--
 The type of the first argument of this method is a [singleton type](@ref man-singleton-types),
 `Type{Bool}`, the only instance of which is [`Bool`](@ref). Thus, this method is only invoked
 when the first argument is the type value `Bool`. Notice the syntax used for the first
@@ -110,6 +182,17 @@ is never used in the function body. In this example, since the type is a singlet
 would never be any reason to use its value within the body. When invoked, the method
 determines whether a numeric value is true or false as a boolean,
 by comparing it to one and zero:
+-->
+```
+このメソッドの1番目の引数の型は[シングルトン型]（@ ref man-singleton-types）の`Type{Bool}`で、この型のインスタンスは[`Bool`](@ref)だけです。
+したがって、このメソッドは、最初の引数が型の値を示す`Bool`である場合にのみ呼び出されます。
+最初の引数の構文に注目してください。
+`::`という記号の前にあるはずの引数名は省略され、型だけが指定されています。
+これはJuliaの関数の構文で、引数の型は指定するけれども、引数の値は関数本体でまったく使わない時に用います。
+この例では、型はシングルトンであるため、その値を関数本体内で使う理由がありません。
+このメソッドを呼び出すと、数値を1や0と比較して、真偽値を決定します。
+
+
 
 ```jldoctest
 julia> convert(Bool, 1)
@@ -127,20 +210,34 @@ julia> convert(Bool, 0im)
 false
 ```
 
+
+```@raw html
+<!--
 The method signatures for conversion methods are often quite a bit more involved than this example,
 especially for parametric types. The example above is meant to be pedagogical, and is not the
 actual Julia behaviour. This is the actual implementation in Julia:
+-->
+```
+変換メソッドのシグネチャは、この例よりもかなり複雑です。特にパラメトリック型のシグネチャは複雑です。上記の例は教育用で、実際のJuliaの動作ではありません。実際のJuliaの実装はこうです。
+
 
 ```julia
 convert(::Type{T}, z::Complex) where {T<:Real} =
     (imag(z) == 0 ? convert(T, real(z)) : throw(InexactError()))
 ```
 
-### [Case Study: Rational Conversions](@id man-rational-conversion)
+[](### [Case Study: Rational Conversions](@id man-rational-conversion))
+### [事例研究: 有理数の変換](@id man-rational-conversion)
 
+
+```@raw html
+<!--
 To continue our case study of Julia's [`Rational`](@ref) type, here are the conversions declared in
 [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
 right after the declaration of the type and its constructors:
+-->
+```
+Juliaの[`Rational`](@ref)型の事例研究を継続し、ここでは、[`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)で宣言されている変換を見てみましょう。これは、型とコンストラクタの宣言の直後に書かれています。
 
 ```julia
 convert(::Type{Rational{T}}, x::Rational) where {T<:Integer} = Rational(convert(T,x.num),convert(T,x.den))
@@ -167,6 +264,9 @@ convert(::Type{T}, x::Rational) where {T<:AbstractFloat} = convert(T,x.num)/conv
 convert(::Type{T}, x::Rational) where {T<:Integer} = div(convert(T,x.num),convert(T,x.den))
 ```
 
+
+```@raw html
+<!--
 The initial four convert methods provide conversions to rational types. The first method converts
 one type of rational to another type of rational by converting the numerator and denominator to
 the appropriate integer type. The second method does the same conversion for integers by taking
@@ -174,14 +274,35 @@ the denominator to be 1. The third method implements a standard algorithm for ap
 floating-point number by a ratio of integers to within a given tolerance, and the fourth method
 applies it, using machine epsilon at the given value as the threshold. In general, one should
 have `a//b == convert(Rational{Int64}, a/b)`.
+-->
+```
 
+最初の4つの変換メソッドは、有理数型への変換を行います。
+第1のメソッドは、分子と分母を適切な整数型に変換して、ある有理数の型から別の有理数の型に変換します。
+第2のメソッドは、分母に1を置いて、整数に対して同様な変換を行います。
+第3のメソッドは、整数の比を与えられた許容誤差内で浮動小数点数に近似する標準的なアルゴリズムを実装して、
+第4のメソッドは、与えられた計算機イプシロンを閾値として第3のメソッドを適用します。
+概ね、`a//b == convert(Rational{Int64}, a/b)`という式が成り立たなければなりません。
+
+
+```@raw html
+<!--
 The last two convert methods provide conversions from rational types to floating-point and integer
 types. To convert to floating point, one simply converts both numerator and denominator to that
 floating point type and then divides. To convert to integer, one can use the `div` operator for
 truncated integer division (rounded towards zero).
+-->
+```
+最後の2つの変換メソッドは、有理数型から浮動小数点型および整数型への変換を行います。
+浮動小数点数に変換するには、分子と分母の両方を浮動小数点数型に変換してから除算を行うだけです。
+整数に変換するには、整数の除算を切り捨てる（ゼロに丸める）`div`演算子を使用できます。
 
-## Promotion
+[](## Promotion)
+## 昇格
 
+
+```@raw html
+<!--
 Promotion refers to converting values of mixed types to a single common type. Although it is not
 strictly necessary, it is generally implied that the common type to which the values are converted
 can faithfully represent all of the original values. In this sense, the term "promotion" is appropriate
@@ -191,11 +312,29 @@ input values in a single common type. It is important, however, not to confuse t
 do with the type hierarchy, and everything to do with converting between alternate representations.
 For instance, although every [`Int32`](@ref) value can also be represented as a [`Float64`](@ref) value,
 `Int32` is not a subtype of `Float64`.
+-->
+```
+昇格とは、型の混在した複数の値を単一の共通の型に変換することを指します。
+値の変換される共通の型は元の値をすべて忠実に表現できるという条件は、必須ではありませんが、通常は満たすことが想定されています。
+この意味では、「昇格」という用語は適切で、値は「より大きな」型に変換されます。
+そして、すべての入力値を単一の共通型で表すことができます。
+しかし重要なことですが、昇格をオブジェクト指向の（構造的）スーパータイプやJuliaの抽象型のスーパータイプという概念と混同しないでください。
+昇格は型の階層とは関連がなく、代替的な表現どうしの変換のみに関連する概念です。
+たとえば、すべての [`Int32`](@ref) の値は[`Float64`](@ref)の値として表現できますが、 `Int32`は`Float64`のサブタイプではありません。
 
+
+
+```@raw html
+<!--
 Promotion to a common "greater" type is performed in Julia by the `promote` function, which takes
 any number of arguments, and returns a tuple of the same number of values, converted to a common
 type, or throws an exception if promotion is not possible. The most common use case for promotion
 is to convert numeric arguments to a common type:
+-->
+```
+
+共通の「より大きな」型に昇格するには、Juliaでは`promote`関数を使います。
+この関数は、任意の数の引数をとって、同じ数の共通の型に変換された値のタプルを返し、また昇格が不可能な場合は例外を投げます。昇格の一番よくある使い方は、数値の引数を共通の型に変換することです。
 
 ```jldoctest
 julia> promote(1, 2.5)
@@ -217,17 +356,37 @@ julia> promote(1 + 2im, 3//4)
 (1//1 + 2//1*im, 3//4 + 0//1*im)
 ```
 
+
+```@raw html
+<!--
 Floating-point values are promoted to the largest of the floating-point argument types. Integer
 values are promoted to the larger of either the native machine word size or the largest integer
 argument type. Mixtures of integers and floating-point values are promoted to a floating-point
 type big enough to hold all the values. Integers mixed with rationals are promoted to rationals.
 Rationals mixed with floats are promoted to floats. Complex values mixed with real values are
 promoted to the appropriate kind of complex value.
+-->
+```
 
+浮動小数点数は、浮動小数点数の引数の型の中で最大のものに昇格されます。
+整数値は、ネイティブマシンのワードサイズと整数の引数の型の最大のものとのどちらか大きい方に昇格されます。
+整数と浮動小数点数の混合した場合は、すべての値を保持するのに十分な大きさの浮動小数点型に昇格されます。
+整数と有理数の混合した場合は有理数に昇格されます。
+有理数と浮動小数点数の混合した場合は、浮動小数点数に昇格されます。
+複素数と実数の混合した場合は、複素数の適切な型に昇格されます。
+
+```@raw html
+<!--
 That is really all there is to using promotions. The rest is just a matter of clever application,
-the most typical "clever" application being the definition of catch-all methods for numeric operations
+the most  "clever" application being the definition of catch-all methods for numeric operations
 like the arithmetic operators `+`, `-`, `*` and `/`. Here are some of the catch-all method definitions
 given in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl):
+-->
+```
+昇格の使用法についてはこれがすべてです。あとはうまい適用の話だけです。
+最も「うまい」適用は、 `+`、 `-`、 `*` 、`/`のような算術演算子用の全捕捉メソッドの定義です。
+ここで [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl)で定義された
+全捕捉メソッドの一部を見てみましょう。
 
 ```julia
 +(x::Number, y::Number) = +(promote(x,y)...)
@@ -236,6 +395,9 @@ given in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/pr
 /(x::Number, y::Number) = /(promote(x,y)...)
 ```
 
+
+```@raw html
+<!--
 These method definitions say that in the absence of more specific rules for adding, subtracting,
 multiplying and dividing pairs of numeric values, promote the values to a common type and then
 try again. That's all there is to it: nowhere else does one ever need to worry about promotion
@@ -247,12 +409,28 @@ common usages of `promote` occur in outer constructors methods, provided for con
 constructor calls with mixed types to delegate to an inner type with fields promoted to an appropriate
 common type. For example, recall that [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)
 provides the following outer constructor method:
+-->
+```
+これらのメソッド定義では、数値のペアに対して、例えば、加算、減算、乗算、除算を行う、より特化した規則がない場合、値を共通型に昇格してから演算を行います。
+昇格を行うのはこれらだけです。他の場所で算術演算の共通の数値型への昇格を心配する必要はありません。
+自動的に処理されます。
+他にいくつもの算術関数や数学関数の全捕捉昇格メソッドの定義が[`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl)にありますが、
+それら以外で、Juliaの標準ライブラリで必要となる`promote`の呼び出しはほとんどありません。
+外部コンストラクターメソッドで一番よく見かける`promote`の使い方は、利便性をあげるため、異なる型が混ざったコンストラクター呼び出しを可能にすることでしょう。
+これば、引数を適切な共通型に昇格し、その型をフィールドに持つ内部型に、コンストラクター呼び出しを委譲して実現します。
+たとえば [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl)では、以下のような外部コンストラクタメソッドが利用可能なことを思い出してください。
 
 ```julia
 Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 ```
 
+
+```@raw html
+<!--
 This allows calls like the following to work:
+-->
+```
+これにより、次のような呼び出しが可能になります。
 
 ```jldoctest
 julia> Rational(Int8(15),Int32(-5))
@@ -262,57 +440,120 @@ julia> typeof(ans)
 Rational{Int32}
 ```
 
+
+```@raw html
+<!--
 For most user-defined types, it is better practice to require programmers to supply the expected
 types to constructor functions explicitly, but sometimes, especially for numeric problems, it
 can be convenient to do promotion automatically.
+-->
+```
 
-### Defining Promotion Rules
+大抵のユーザー定義型では、プログラマーがコンストラクター関数に想定される型を明示的に指定するのがよいと思いますが、時には自動昇格を使うと、特に数値問題の場合は、便利なものです。
 
+[](### Defining Promotion Rules)
+### 昇格規則の定義
+
+
+```@raw html
+<!--
 Although one could, in principle, define methods for the `promote` function directly, this would
 require many redundant definitions for all possible permutations of argument types. Instead, the
 behavior of `promote` is defined in terms of an auxiliary function called `promote_rule`, which
 one can provide methods for. The `promote_rule` function takes a pair of type objects and returns
 another type object, such that instances of the argument types will be promoted to the returned
 type. Thus, by defining the rule:
+-->
+```
+
+原理的には`promote`関数のメソッドを直接定義することができますが、そのためには、すべてのおこりうる引数の型の置換に対して多くの冗長な定義が必要になります。
+その代わりに、`promote`関数の挙動の定義を、`promote_rule`という補助的な関数のメソッドを定義して行うことができます。
+この`promote_rule`関数は、型オブジェクトのペアを引数に取って、別の型オブジェクトを返しますが、
+これは引数の型のインスタンスが戻り値の型に昇格されることを意味しているので、そうなるように規則を定義します。
+
 
 ```julia
 promote_rule(::Type{Float64}, ::Type{Float32}) = Float64
 ```
 
+
+```@raw html
+<!--
 one declares that when 64-bit and 32-bit floating-point values are promoted together, they should
 be promoted to 64-bit floating-point. The promotion type does not need to be one of the argument
 types, however; the following promotion rules both occur in Julia's standard library:
+-->
+```
+
+64ビット浮動小数点数と32ビット浮動小数点数を一緒に昇格するときは、64ビット浮動小数点数に昇格する必要があります。
+しかし昇格後の型は引数の型の1つである必要はありません。
+次の昇格規則は共にJuliaの標準ライブラリにあるものです。
 
 ```julia
 promote_rule(::Type{UInt8}, ::Type{Int8}) = Int
 promote_rule(::Type{BigInt}, ::Type{Int8}) = BigInt
 ```
 
+
+```@raw html
+<!--
 In the latter case, the result type is [`BigInt`](@ref) since `BigInt` is the only type
 large enough to hold integers for arbitrary-precision integer arithmetic. Also note that
 one does not need to define both `promote_rule(::Type{A}, ::Type{B})` and
 `promote_rule(::Type{B}, ::Type{A})` -- the symmetry is implied by the way `promote_rule`
 is used in the promotion process.
+-->
+```
 
+後者の場合、昇格後の型は[`BigInt`](@ref)になります。
+というのも`BigInt`だけが、任意の精度の整数演算に対して整数を保持する大きさを持つの唯一の型だからです。
+`promote_rule(::Type{A}, ::Type{B})`と `promote_rule(::Type{B}, ::Type{A})`の両方を定義する必要はない点に注意してください。`promote_rule`は、昇格の処理の際に、対称性を前提として使われます。
+
+
+```@raw html
+<!--
 The `promote_rule` function is used as a building block to define a second function called `promote_type`,
 which, given any number of type objects, returns the common type to which those values, as arguments
 to `promote` should be promoted. Thus, if one wants to know, in absence of actual values, what
 type a collection of values of certain types would promote to, one can use `promote_type`:
+-->
+```
+`promote_rule`関数を構成要素として使って、`promote_type`という二次的な関数を定義します。
+`promote_type`関数は、任意の数の型オブジェクトを引数にとり、これらの値の共通の型を返します。
+この型が`promote`関数が引数を昇格後にとるべき型となります。
+したがって、実際の値が存在しなくても、`promote_type`を使えば、型の値の集合が昇格するとどんな型になるかを調べることができます。
+
 
 ```jldoctest
 julia> promote_type(Int8, UInt16)
 Int64
 ```
 
+
+```@raw html
+<!--
 Internally, `promote_type` is used inside of `promote` to determine what type argument values
 should be converted to for promotion. It can, however, be useful in its own right. The curious
 reader can read the code in [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl),
 which defines the complete promotion mechanism in about 35 lines.
+-->
+```
 
-### Case Study: Rational Promotions
+内部的には、`promote_type`は`promote`の内部で、引数値を昇格してどんな型に変換するかを決定するために使用されますが、`promote_type`単体でも有用なことがあります。
+興味のある読者は約35行で完全な昇格の仕組みを定義するコードを [`promotion.jl`](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl)で読むことができます。
 
+
+[](### Case Study: Rational Promotions)
+### 事例研究: 有理数の昇格
+
+
+```@raw html
+<!--
 Finally, we finish off our ongoing case study of Julia's rational number type, which makes relatively
 sophisticated use of the promotion mechanism with the following promotion rules:
+-->
+```
+とうとう、ここまで進めてきたJuliaの有理数型の事例研究が完成します。ここでは、以下の昇格規則による昇格メカニズムを比較的洗練された手法で利用しています。
 
 ```julia
 promote_rule(::Type{Rational{T}}, ::Type{S}) where {T<:Integer,S<:Integer} = Rational{promote_type(T,S)}
@@ -320,15 +561,32 @@ promote_rule(::Type{Rational{T}}, ::Type{Rational{S}}) where {T<:Integer,S<:Inte
 promote_rule(::Type{Rational{T}}, ::Type{S}) where {T<:Integer,S<:AbstractFloat} = promote_type(T,S)
 ```
 
+
+```@raw html
+<!--
 The first rule says that promoting a rational number with any other integer type promotes to a
 rational type whose numerator/denominator type is the result of promotion of its numerator/denominator
 type with the other integer type. The second rule applies the same logic to two different types
 of rational numbers, resulting in a rational of the promotion of their respective numerator/denominator
 types. The third and final rule dictates that promoting a rational with a float results in the
 same type as promoting the numerator/denominator type with the float.
+-->
+```
 
+第1の規則は、有理数型と整数型を昇格すると、有理数型に昇格し、その分子/分母の型は元の有理数の分子/分母の型と整数型を昇格した型になることを示しています。
+第2の規則は、2つの異なる有理数型を昇格すると、同様の論理を適用して、各有理数型の分子/分母の型を昇格した型を分子/分母の型とするような有理数型に昇格することを示しています。
+最後の3つ目の規則は、有理数型と浮動小数点型を昇格すると、浮動小数点型に昇格し、その型は有理数型の分子/分母の型と浮動小数点数型を昇格した結果と同じ型になることを示しています。
+
+```@raw html
+<!--
 This small handful of promotion rules, together with the [conversion methods discussed above](@ref man-rational-conversion),
 are sufficient to make rational numbers interoperate completely naturally with all of Julia's
 other numeric types -- integers, floating-point numbers, and complex numbers. By providing appropriate
 conversion methods and promotion rules in the same manner, any user-defined numeric type can interoperate
 just as naturally with Julia's predefined numerics.
+-->
+```
+この少数の昇格規則と、[前述の変換メソッド]（@ ref man-rational-conversion）だけで十分、有理数型をとても自然にJuliaの他の数値型、つまり 整数、浮動小数点数、複素数と一緒に使うことができます。
+同様に、適切な変換メソッドと昇格規則を定義すれば、どんなユーザー定義の数値型でも自然に、Juliaで事前定義されている数値型と一緒に使うことができます。
+
+    ©2017 GitHub

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -720,7 +720,7 @@ call will fail, just as it would if too many arguments were given explicitly.
 
 
 [](## Optional Arguments)
-## 省略可能引数
+## オプション引数
 
 ```@raw html
 <!-
@@ -776,8 +776,8 @@ with different numbers of arguments (see [Note on Optional and keyword Arguments
 -->
 ```
 
-省略可能な引数は、実際には、引数の個数の違う複数のメソッドの定義を書くための便利な構文なのです。
-( [省略可能引数とキーワード引数の注意点](@ref) を参照).
+オプション引数は、実際には、引数の個数の違う複数のメソッドの定義を書くための便利な構文なのです。
+( [オプション引数とキーワード引数の注意点](@ref) を参照).
 
 
 [](## Keyword Arguments)
@@ -933,8 +933,8 @@ contrast, *all* the arguments are in scope when keyword arguments default expres
 For example, given this definition:
 -->
 ```
-省略可能引数とキーワード引数は式のデフォルト値が評価される方法が少し違います。
-省略可能引数のデフォルトの式が評価される際、スコープに存在するのは、既に評価された引数だけです。
+オプション引数とキーワード引数は式のデフォルト値が評価される方法が少し違います。
+オプション引数のデフォルトの式が評価される際、スコープに存在するのは、既に評価された引数だけです。
 一方、キーワード引数が評価される際には、すべての引数のデフォルトの式がスコープ内に存在します。
 次式のような定義を例に挙げます。
 

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -1,11 +1,27 @@
-# Interfaces
+[](# Interfaces)
+# インターフェース
 
+
+```@raw html
+<!--
 A lot of the power and extensibility in Julia comes from a collection of informal interfaces.
  By extending a few specific methods to work for a custom type, objects of that type not only
 receive those functionalities, but they are also able to be used in other methods that are written
 to generically build upon those behaviors.
+-->
+```
 
-## [Iteration](@id man-interface-iteration)
+Juliaに仮に実装されている様々なインターフェースは、この言語の力と拡張性の源となっています。
+このインターフェースを独自型に特化したメソッドに拡張すると、特化したメソッドは、直接呼び出しても、汎化的に記述されたメソッドから呼び出しても、その型のオブジェクトでは機能します。
+
+
+
+[](## [Iteration](@id man-interface-iteration))
+## [繰返し](@id man-interface-iteration)
+
+
+```@raw html
+<!--
 
 | Required methods               |                        | Brief description                                                                     |
 |:------------------------------ |:---------------------- |:------------------------------------------------------------------------------------- |
@@ -31,6 +47,35 @@ to generically build upon those behaviors.
 | `HasEltype()`                                | `eltype(IterType)` |
 | `EltypeUnknown()`                            | (*none*)           |
 
+-->
+```
+| 必須メソッド               |                        | 概説                                                                     |
+|:------------------------------ |:---------------------- |:------------------------------------------------------------------------------------- |
+| `start(iter)`                  |                        | 繰り返しの初期状態を返します。                                                   |
+| `next(iter, state)`            |                        | 現在のアイテムと次の状態を返します。                                           |
+| `done(iter, state)`            |                        | 残りのアイテムがあるかどうか検査します。                                                |
+| **重要な必須ではないメソッド** | **デフォルトのメソッド** | **概説**                                                                 |
+| `iteratorsize(IterType)`       | `HasLength()`          | `HasLength()`, `HasShape()`, `IsInfinite()`,  `SizeUnknown()` の中で適切なもの一つ|
+| `iteratoreltype(IterType)`     | `HasEltype()`          | `EltypeUnknown()`と`HasEltype()`のどちらか適切のもの                              |
+| `eltype(IterType)`             | `Any`                  | `next()`が返すアイテムの型                                               |
+| `length(iter)`                 | (*undefined*)          | アイテムの数(既知の場合)                                                         |
+| `size(iter, [dim...])`         | (*undefined*)          | 各次元のアイテムの数(既知の場合)                                           |
+
+| `iteratorsize(IterType)`の戻り値 | 必要なメソッド                           |
+|:------------------------------------------ |:------------------------------------------ |
+| `HasLength()`                              | `length(iter)`                             |
+| `HasShape()`                               | `length(iter)`と`size(iter, [dim...])` |
+| `IsInfinite()`                             | (*none*)                                   |
+| `SizeUnknown()`                            | (*none*)                                   |
+
+|  `iteratoreltype(IterType)`の戻り値  |必要なメソッド  |
+|:-------------------------------------------- |:------------------ |
+| `HasEltype()`                                | `eltype(IterType)` |
+| `EltypeUnknown()`                            | (*none*)           |
+
+
+```@raw html
+<!--
 Sequential iteration is implemented by the methods [`start()`](@ref), [`done()`](@ref), and [`next()`](@ref). Instead
 of mutating objects as they are iterated over, Julia provides these three methods to keep track
 of the iteration state externally from the object. The `start(iter)` method returns the initial
@@ -38,9 +83,26 @@ state for the iterable object `iter`. That state gets passed along to `done(iter
 tests if there are any elements remaining, and `next(iter, state)`, which returns a tuple containing
 the current element and an updated `state`. The `state` object can be anything, and is generally
 considered to be an implementation detail private to the iterable object.
+-->
+```
+順次実行される繰返し処理は、[`start()`](@ref), [`done()`](@ref), [`next()`] (@ref) のメソッドをつかって実装されています。
+Juliaでは、繰返し処理の状態の追跡は、この3つのメソッドを使ってオブジェクトの外部から行われ、処理の行われるオブジェクトには変更を加えません。
+この`start(iter)`メソッドは、イテラブルオブジェクト`iter`の初期状態を返し、
+その状態は`done(iter, state)`、`next(iter, state)`と順に渡されます。
+`done(iter, state)`は残りの要素があるかどうかを検査し、`next(iter, state)`は現在の要素と更新された`state`オブジェクトを含むタプルを返します。
+`state`オブジェクトは何でも構いませんが、通常はイテラブルオブジェクト内でプライベートな実装の詳細を示すものでしょう。
 
+
+
+```@raw html
+<!--
 Any object defines these three methods is iterable and can be used in the [many functions that rely upon iteration](@ref lib-collections-iteration).
 It can also be used directly in a `for` loop since the syntax:
+-->
+```
+これらの3つのメソッドが定義されたオブジェクトはすべてイテラブルであり、[繰返しを使う多数の関数]（@ ref lib-collections-iteration）で使用できます。
+また以下のような構文で`for`ループ内で直接使用することもできます。
+
 
 ```julia
 for i in iter   # or  "for i = iter"
@@ -48,7 +110,13 @@ for i in iter   # or  "for i = iter"
 end
 ```
 
+
+```@raw html
+<!--
 is translated into:
+-->
+```
+上記の構文は以下のように変換されます。
 
 ```julia
 state = start(iter)
@@ -58,7 +126,14 @@ while !done(iter, state)
 end
 ```
 
+
+```@raw html
+<!--
 A simple example is an iterable sequence of square numbers with a defined length:
+-->
+```
+簡単な例は、イテラブルな長さの決まった平方数の数列です。
+
 
 ```jldoctest squaretype
 julia> struct Squares
@@ -76,8 +151,16 @@ julia> Base.eltype(::Type{Squares}) = Int # Note that this is defined for the ty
 julia> Base.length(S::Squares) = S.count
 ```
 
+
+```@raw html
+<!--
 With only [`start`](@ref), [`next`](@ref), and [`done`](@ref) definitions, the `Squares` type is already pretty powerful.
 We can iterate over all the elements:
+-->
+```
+[`start`](@ref), [`next`](@ref),  [`done`](@ref) の定義だけでも、`Squares`型はすでにかなり強力です。
+すべての要素に対する繰り返し処理を実行できます。
+
 
 ```jldoctest squaretype
 julia> for i in Squares(7)
@@ -92,7 +175,14 @@ julia> for i in Squares(7)
 49
 ```
 
+
+```@raw html
+<!--
 We can use many of the builtin methods that work with iterables, like [`in()`](@ref), [`mean()`](@ref) and [`std()`](@ref):
+-->
+```
+[`in()`](@ref), [`mean()`](@ref), [`std()`](@ref) のような多くの標準装備のメソッドがイテラブルオブジェクトで動作します。
+
 
 ```jldoctest squaretype
 julia> 25 in Squares(10)
@@ -105,14 +195,32 @@ julia> std(Squares(100))
 3024.355854282583
 ```
 
+
+```@raw html
+<!--
 There are a few more methods we can extend to give Julia more information about this iterable
 collection.  We know that the elements in a `Squares` sequence will always be `Int`. By extending
 the [`eltype()`](@ref) method, we can give that information to Julia and help it make more specialized
 code in the more complicated methods. We also know the number of elements in our sequence, so
 we can extend [`length()`](@ref), too.
+-->
+```
+さらに、対象とするイテラブルコレクションに関する詳しい情報を与えるために、拡張して使うメソッドがJuliaにはいくつかあります。
+`Squares`の数列の要素は常に`Int`であることがわかっています。
+ [`eltype()`](@ref)メソッドを拡張して、この情報をJuliaに渡すと、もっと複雑なメソッドでも、もっと型に特化したコードを作成するのに役立てることができます。
+シーケンスの要素数もわかっているので[`length()`](@ref)も拡張することもできます。
 
+
+
+```@raw html
+<!--
 Now, when we ask Julia to [`collect()`](@ref) all the elements into an array it can preallocate a `Vector{Int}`
 of the right size instead of blindly [`push!`](@ref)ing each element into a `Vector{Any}`:
+-->
+```
+ここまでくれば、Juliaで、 すべての要素を[`collect()`](@ref) を使って配列化する際に、
+`Vector{Int}`のように 正しいサイズに事前に割り当てることができます。[`push!`](@ref)を使って盲目的に各要素を`Vector{Any}`におしこまなくてもよいのです。
+
 
 ```jldoctest squaretype
 julia> collect(Squares(10))' # transposed to save space
@@ -120,9 +228,17 @@ julia> collect(Squares(10))' # transposed to save space
  1  4  9  16  25  36  49  64  81  100
 ```
 
+
+```@raw html
+<!--
 While we can rely upon generic implementations, we can also extend specific methods where we know
 there is a simpler algorithm. For example, there's a formula to compute the sum of squares, so
 we can override the generic iterative version with a more performant solution:
+-->
+```
+汎化的な実装のまま使うこともできますが、もっと単純なアルゴリズムがあると分かっている場合は、特化したメソッドに拡張することもできます。
+たとえば、平方和を算出する公式があれば、汎化的な繰返しをもっと効率的な解法で上書きすることができます。
+
 
 ```jldoctest squaretype
 julia> Base.sum(S::Squares) = (n = S.count; return n*(n+1)*(2n+1)÷6)
@@ -131,22 +247,51 @@ julia> sum(Squares(1803))
 1955361914
 ```
 
+
+```@raw html
+<!--
 This is a very common pattern throughout the Julia standard library: a small set of required methods
 define an informal interface that enable many fancier behaviors. In some cases, types will want
 to additionally specialize those extra behaviors when they know a more efficient algorithm can
 be used in their specific case.
+-->
+```
+これは、Julia標準ライブラリ全体に非常によくあるパターンです。
+少数の必須メソッドによって仮実装のインターフェイスが定義され、多くの便利な動作が利用可能となっています。
+もっと効率的なアルゴリズムを使用できる場合には、さらに型に特化させてその動作を行うことができます。
 
-## Indexing
+[](## Indexing)
+## インデックス
 
+
+```@raw html
+<!--
 | Methods to implement | Brief description                |
 |:-------------------- |:-------------------------------- |
 | `getindex(X, i)`     | `X[i]`, indexed element access   |
 | `setindex!(X, v, i)` | `X[i] = v`, indexed assignment   |
 | `endof(X)`           | The last index, used in `X[end]` |
+-->
+```
 
+| 実装すべきメソッド | 概説                |
+|:-------------------- |:-------------------------------- |
+| `getindex(X, i)`     | `X[i]`, インデックスによる要素の参照   |
+| `setindex!(X, v, i)` | `X[i] = v`,  インデックスによる代入   |
+| `endof(X)`           | インデックスの最後尾,  `X[end]`で使われる |
+
+
+```@raw html
+<!--
 For the `Squares` iterable above, we can easily compute the `i`th element of the sequence by squaring
 it.  We can expose this as an indexing expression `S[i]`. To opt into this behavior, `Squares`
 simply needs to define [`getindex()`](@ref):
+-->
+```
+上記の`Squares`イテラブルでは、数列の`i`番目は、2乗すれば簡単に算出できます。
+`S[i]`というインデックス式で、これを公開することができます。
+`Squares` に[`getindex()`](@ref) を定義すればいいだけです。
+
 
 ```jldoctest squaretype
 julia> function Base.getindex(S::Squares, i::Int)
@@ -158,8 +303,15 @@ julia> Squares(100)[23]
 529
 ```
 
+
+```@raw html
+<!--
 Additionally, to support the syntax `S[end]`, we must define [`endof()`](@ref) to specify the last valid
 index:
+-->
+```
+さらに、`S[end]`構文を使えるようにするには、[`endof()`](@ref)を定義して有効な最後尾のインデックスを指定する必要があります。
+
 
 ```jldoctest squaretype
 julia> Base.endof(S::Squares) = length(S)
@@ -168,9 +320,18 @@ julia> Squares(23)[end]
 529
 ```
 
+
+```@raw html
+<!--
 Note, though, that the above *only* defines [`getindex()`](@ref) with one integer index. Indexing with
 anything other than an `Int` will throw a [`MethodError`](@ref) saying that there was no matching method.
 In order to support indexing with ranges or vectors of `Int`s, separate methods must be written:
+-->
+```
+ただし、上記は [`getindex()`](@ref) を1つの整数インデックスで**のみ**定義していることに注意してください。
+`Int`以外のものを使ってインデックスを使うと [`MethodError`](@ref) を投げて、適合するメソッドが存在しないというメッセージが表示されるでしょう。
+範囲や`Int`のベクトルに対してインデックスをつかう場合は、別のメソッドを記述する必要があります。
+
 
 ```jldoctest squaretype
 julia> Base.getindex(S::Squares, i::Number) = S[convert(Int, i)]
@@ -184,17 +345,29 @@ julia> Squares(10)[[3,4.,5]]
  25
 ```
 
+
+```@raw html
+<!--
 While this is starting to support more of the [indexing operations supported by some of the builtin types](@ref man-array-indexing),
 there's still quite a number of behaviors missing. This `Squares` sequence is starting to look
 more and more like a vector as we've added behaviors to it. Instead of defining all these behaviors
 ourselves, we can officially define it as a subtype of an [`AbstractArray`](@ref).
+-->
+```
+[一部の標準装備の型で可能なインデックス操作]（@ ref man-array-indexing）をがけっこう使えるようになりましたが、依然として動作しないものが多くあります。
+この`Squares`シーケンスに、もっと動作を加えると、ますますベクトルのように見えます。
+これらの動作はすべてを自前で定義しなくても、正式な [`AbstractArray`](@ref)のサブタイプとして定義することができます。
 
-## [Abstract Arrays](@id man-interface-array)
+[](## [Abstract Arrays](@id man-interface-array))
+## [抽象配列](@id man-interface-array)
 
+
+```@raw html
+<!--
 | Methods to implement                            |                                          | Brief description                                                                     |
 |:----------------------------------------------- |:---------------------------------------- |:------------------------------------------------------------------------------------- |
 | `size(A)`                                       |                                          | Returns a tuple containing the dimensions of `A`                                      |
-| `getindex(A, i::Int)`                           |                                          | (if `IndexLinear`) Linear scalar indexing                                              |
+| `getindex(A, i::Int)`                           |                                      ｓ    | (if `IndexLinear`) Linear scalar indexing                                              |
 | `getindex(A, I::Vararg{Int, N})`                |                                          | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexing                 |
 | `setindex!(A, v, i::Int)`                       |                                          | (if `IndexLinear`) Scalar indexed assignment                                           |
 | `setindex!(A, v, I::Vararg{Int, N})`            |                                          | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexed assignment       |
@@ -212,11 +385,45 @@ ourselves, we can officially define it as a subtype of an [`AbstractArray`](@ref
 | `indices(A)`                                    | `map(OneTo, size(A))`                    | Return the `AbstractUnitRange` of valid indices                                       |
 | `Base.similar(A, ::Type{S}, inds::NTuple{Ind})` | `similar(A, S, Base.to_shape(inds))`     | Return a mutable array with the specified indices `inds` (see below)                  |
 | `Base.similar(T::Union{Type,Function}, inds)`   | `T(Base.to_shape(inds))`                 | Return an array similar to `T` with the specified indices `inds` (see below)          |
+-->
+```
+| 実装すべきメソッド                            |                                          | 概説                                                                     |
+|:----------------------------------------------- |:---------------------------------------- |:------------------------------------------------------------------------------------- |
+| `size(A)`                                       |                                          | `A`の次元を含むタプルを返す                                      |
+| `getindex(A, i::Int)`                           |                                          | ( `IndexLinear`)線形スカラインデックスによる参照                                              |
+| `getindex(A, I::Vararg{Int, N})`                |                                          | ( `IndexCartesian`,`N = ndims(A)`) N次元のスカラインデックスにによる参照                |
+| `setindex!(A, v, i::Int)`                       |                                          | ( `IndexLinear`) 線形スカラインデックスによる代入                                           |
+| `setindex!(A, v, I::Vararg{Int, N})`            |                                          | ( `IndexCartesian`, `N = ndims(A)`) N次元のスカラインデックスによる代入       |
+| **省略可能なメソッド**                            | **デフォルトの定義**                   | **概説**                                                                 |
+| `IndexStyle(::Type)`                            | `IndexCartesian()`                       |  `IndexLinear()` と `IndexCartesian()`のどちらかを返す。下記参照      |
+| `getindex(A, I...)`                             | スカラーの  `getindex()`による定義  | [多次元で非スカラーのインデックスによる参照](@ref man-array-indexing)                    |
+| `setindex!(A, I...)`                            | スカラーの `setindex!()`による定義 | [多次元で非スカラーのインデックスによる代入](@ref man-array-indexing)          |
+| `start()`/`next()`/`done()`                     | スカラーの `getindex()`による定義  | 繰返し                                                                             |
+| `length(A)`                                     | `prod(size(A))`                          | 要素の数                                                                    |
+| `similar(A)`                                    | `similar(A, eltype(A), size(A))`         | 同形・同要素型の可変配列を返す                          |
+| `similar(A, ::Type{S})`                         | `similar(A, S, size(A))`                 | 同形・指定要素型の可変配列を返す|
+| `similar(A, dims::NTuple{Int})`                 | `similar(A, eltype(A), dims)`            | 同要素型でサイズ**dims**の可変配列を返す |
+| `similar(A, ::Type{S}, dims::NTuple{Int})`      | `Array{S}(dims)`                         | 指定形・指定要素型の可変配列を返す|
+| **通常とは異なるインデックス**                     | **デフォルトの定義**                   | **概説**                                                                 |
+| `indices(A)`                                    | `map(OneTo, size(A))`                    | 妥当なインデックスの`AbstractUnitRange`を返す                                       |
+| `Base.similar(A, ::Type{S}, inds::NTuple{Ind})` | `similar(A, S, Base.to_shape(inds))`     | `inds`で指定したインデックスの可変配列を返す (下記参照)                  |
+| `Base.similar(T::Union{Type,Function}, inds)`   | `T(Base.to_shape(inds))`                 | `inds`で指定したインデックスの`T`と同様な可変配列を返す (下記参照)          |
 
+
+```@raw html
+<!--
 If a type is defined as a subtype of `AbstractArray`, it inherits a very large set of rich behaviors
 including iteration and multidimensional indexing built on top of single-element access.  See
 the [arrays manual page](@ref man-multi-dim-arrays) and [standard library section](@ref lib-arrays) for more supported methods.
+-->
+```
+`AbstractArray`のサブタイプとして定義された型は、多様な動作を数多く継承していて、反復処理や、1要素アクセスをもとに構築された多次元インデックスなどが利用できます。
+その他の利用可能なメソッドについては、[多次元配列のマニュアルページ]（@ ref man-multi-dim-arrays）と[標準ライブラリの配列のセクション]（@ ref lib-arrays）を参照してください。
 
+
+
+```@raw html
+<!--
 A key part in defining an `AbstractArray` subtype is [`IndexStyle`](@ref). Since indexing is
 such an important part of an array and often occurs in hot loops, it's important to make both
 indexing and indexed assignment as efficient as possible.  Array data structures are typically
@@ -225,7 +432,19 @@ defined in one of two ways: either it most efficiently accesses its elements usi
  These two modalities are identified by Julia as `IndexLinear()` and `IndexCartesian()`.
  Converting a linear index to multiple indexing subscripts is typically very expensive, so this
 provides a traits-based mechanism to enable efficient generic code for all array types.
+-->
+```
+`AbstractArray`のサブタイプの定義で重要な部分は[`IndexStyle`](@ref) です。
+インデックスは配列の重要な部分であり、頻繁にループで使わわれるため、インデックスによる参照と代入をできる限り効率的に行うことは重要です。
+配列のデータ構造は、通常、２つの手法のいずれかが定義に採用されます。
+一方は、インデックス（線形インデックス）をただ一つ使用して要素にアクセスする最も効率のよい手法で、もう一方は、本質的にはすべての次元に対してインデックスを指定して要素にアクセスする手法です。
+これらの2つのモードは、Juliaでは`IndexLinear()`と`IndexCartesian()`によって同定されます。
+線形インデックスを多重インデックスの添字に変換するのは、通常非常にコストがかかるので、`IndexStyle`ごとにトレイトに基づくメカニズムを使って、すべての配列の型に対して効率的で汎化的なコードを可能にするメカニズムが備わっています。
 
+
+
+```@raw html
+<!--
 This distinction determines which scalar indexing methods the type must define. `IndexLinear()`
 arrays are simple: just define `getindex(A::ArrayType, i::Int)`.  When the array is subsequently
 indexed with a multidimensional set of indices, the fallback `getindex(A::AbstractArray, I...)()`
@@ -233,12 +452,28 @@ efficiently converts the indices into one linear index and then calls the above 
 arrays, on the other hand, require methods to be defined for each supported dimensionality with
 `ndims(A)``Int` indices.  For example, the builtin `SparseMatrixCSC` type only supports two dimensions,
 so it just defines `getindex(A::SparseMatrixCSC, i::Int, j::Int)()`.  The same holds for `setindex!()`.
+-->
+```
+この`IndexStyle`の違いによって、どのスカラーインデックスのメソッドを型に対して定義しなければならないかが決定します。
+`IndexLinear()`の配列は単純で、`getindex(A::ArrayType, i::Int)`を定義するだけです。
+配列が多次元で複数のインデックスによってインデックス付けされている場合、補助的な関数の`getindex(A::AbstractArray, I...)()` はインデックスを線形インデックスに効率的に変換し、前述のメソッドを呼び出します。
+一方、`IndexCartesian()` の配列は、`ndims(A)`、`Int`の指定によって利用可能となる次元すべてに対して、メソッドを定義する必要があります。
+たとえば、標準装備の`SparseMatrixCSC`型は2次元しか利用可能ではないため、`getindex(A::SparseMatrixCSC, i::Int, j::Int)()`だけを定義しています。`setindex!()`に関しても同様です。
+
+
+
+```@raw html
+<!--
 
 Returning to the sequence of squares from above, we could instead define it as a subtype of an
 `AbstractArray{Int, 1}`:
+-->
+```
+上記の二乗の数列に戻ると、別の手法として`AbstractArray{Int, 1}`のサブタイプを定義することもできます。
+
 
 ```jldoctest squarevectype
-julia> struct SquaresVector <: AbstractArray{Int, 1}
+julia> struct SquaresVector <: AbstractArray{Int, 1}`
            count::Int
        end
 
@@ -249,10 +484,19 @@ julia> Base.IndexStyle(::Type{<:SquaresVector}) = IndexLinear()
 julia> Base.getindex(S::SquaresVector, i::Int) = i*i
 ```
 
+
+```@raw html
+<!--
 Note that it's very important to specify the two parameters of the `AbstractArray`; the first
 defines the [`eltype()`](@ref), and the second defines the [`ndims()`](@ref). That supertype and those three
 methods are all it takes for `SquaresVector` to be an iterable, indexable, and completely functional
 array:
+-->
+```
+`AbstractArray`の2つのパラメータの指定は、非常に重要であることに注意してください。
+1番目は[`eltype()`](@ref) を定義し、2番目は[`ndims()`](@ref)を定義します。
+このスーパータイプと3つのメソッドのすべてによって、`SquaresVector`はループとインデックスによるアクセスが可能になり、完全に機能する配列となります。
+
 
 ```jldoctest squarevectype
 julia> s = SquaresVector(7)
@@ -279,8 +523,15 @@ julia> s ⋅ s # dot(s, s)
 4676
 ```
 
+
+```@raw html
+<!--
 As a more complicated example, let's define our own toy N-dimensional sparse-like array type built
 on top of [`Dict`](@ref):
+-->
+```
+より複雑な例として、N次元で疎な配列型のおもちゃのようなものを[`Dict`](@ref)を使って定義しましょう。
+
 
 ```jldoctest squarevectype
 julia> struct SparseArray{T,N} <: AbstractArray{T,N}
@@ -301,9 +552,17 @@ julia> Base.getindex(A::SparseArray{T,N}, I::Vararg{Int,N}) where {T,N} = get(A.
 julia> Base.setindex!(A::SparseArray{T,N}, v, I::Vararg{Int,N}) where {T,N} = (A.data[I] = v)
 ```
 
+
+```@raw html
+<!--
 Notice that this is an `IndexCartesian` array, so we must manually define [`getindex()`](@ref) and [`setindex!()`](@ref)
 at the dimensionality of the array. Unlike the `SquaresVector`, we are able to define [`setindex!()`](@ref),
 and so we can mutate the array:
+-->
+```
+これは`IndexCartesian`の配列なので、 [`getindex()`](@ref) と[`setindex!()`](@ref) を次元ごとに手動で定義する必要がある点に注意してください。
+`SquaresVector`配列とは違って、[`setindex!()`](@ref)を定義できるので、配列を更新することができます：
+
 
 ```jldoctest squarevectype
 julia> A = SparseArray(Float64, 3, 3)
@@ -325,11 +584,20 @@ julia> A[:] = 1:length(A); A
  3.0  6.0  9.0
 ```
 
+
+```@raw html
+<!--
 The result of indexing an `AbstractArray` can itself be an array (for instance when indexing by
 a `Range`). The `AbstractArray` fallback methods use [`similar()`](@ref) to allocate an `Array` of the
 appropriate size and element type, which is filled in using the basic indexing method described
 above. However, when implementing an array wrapper you often want the result to be wrapped as
 well:
+-->
+```
+`AbstractArray`をインデックスを使って参照した値は、それ自体が配列になることもあります（たとえば、`Range`を使ってインデックス参照した場合）。
+`AbstractArray`の派生した(コンストラクタ)メソッドは[`similar()`](@ref) を利用して、適切なサイズと基本型の`配列`をメモリに割り当て、上述した基本的なインデックスのメソッドを使ってを値を埋めていきます。
+しかし、配列のラッパーが実装されているときには、当然、結果をラップしたくなることもよくあるでしょう。
+
 
 ```jldoctest squarevectype
 julia> A[1:2,:]
@@ -338,11 +606,21 @@ julia> A[1:2,:]
  2.0  5.0  8.0
 ```
 
+
+```@raw html
+<!--
 In this example it is accomplished by defining `Base.similar{T}(A::SparseArray, ::Type{T}, dims::Dims)`
 to create the appropriate wrapped array. (Note that while `similar` supports 1- and 2-argument
 forms, in most case you only need to specialize the 3-argument form.) For this to work it's important
 that `SparseArray` is mutable (supports `setindex!`). Defining `similar()`, `getindex()` and
 `setindex!()` for `SparseArray` also makes it possible to [`copy()`](@ref) the array:
+-->
+```
+この例では`Base.similar{T}(A::SparseArray, ::Type{T}, dims::Dims)`を定義して、適切にラップされた配列を作成しています。
+（`similar`は1引数や2引数の場合も動作しますが、ほとんどの場合、3引数に特化した場合だけが必要になる点に注意してください。）
+これが動作するには`SparseArray`が可変（`setindex!`を利用可能）であることが重要です。
+`similar()`、`getindex()`、`setindex!()`を`SparseArray`に定義すると、配列を [`copy()`](@ref)することができるようになります。
+
 
 ```jldoctest squarevectype
 julia> copy(A)
@@ -352,8 +630,15 @@ julia> copy(A)
  3.0  6.0  9.0
 ```
 
+
+```@raw html
+<!--
 In addition to all the iterable and indexable methods from above, these types can also interact
 with each other and use most of the methods defined in the standard library for `AbstractArrays`:
+-->
+```
+上記のすべての反復可能なメソッドとインデックス可能なメソッドのほかにも、これらの型は相互に利用することができ、標準ライブラリで定義されている`AbstractArrays`向けのメソッドをほとんど利用できます。
+
 
 ```jldoctest squarevectype
 julia> A[SquaresVector(3)]
@@ -366,7 +651,15 @@ julia> dot(A[:,1],A[:,2])
 32.0
 ```
 
+
+```@raw html
+<!--
 If you are defining an array type that allows non-traditional indexing (indices that start at
 something other than 1), you should specialize `indices`. You should also specialize [`similar`](@ref)
 so that the `dims` argument (ordinarily a `Dims` size-tuple) can accept `AbstractUnitRange` objects,
 perhaps range-types `Ind` of your own design. For more information, see [Arrays with custom indices](@ref).
+-->
+```
+通常ではない（1以外から始まる)インデックスを使うには、`indices`を特化させる必要があります。
+また引数の`dims`（通常は`Dims`のサイズのタプル）が`AbstractUnitRange`オブジェクト、ひょっとすると独自設計の範囲型である`Ind`を受けとれるようにするには、[`similar`](@ref)を特化する必要があります。
+詳細については、[Arrays with custom indices](@ref)を参照してください。

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -1,6 +1,9 @@
-# Methods
+[](# Methods)
 # メソッド
 
+
+```@raw html
+<!--
 Recall from [関数](@ref man-functions) that a function is an object that maps a tuple of arguments to a
 return value, or throws an exception if no appropriate value can be returned. It is common for
 the same conceptual function or operation to be implemented quite differently for different types
@@ -8,7 +11,18 @@ of arguments: adding two integers is very different from adding two floating-poi
 of which are distinct from adding an integer to a floating-point number. Despite their implementation
 differences, these operations all fall under the general concept of "addition". Accordingly, in
 Julia, these behaviors all belong to a single object: the `+` function.
+-->
+```
+[関数]（@ ref man-functions）の章を思い出してください。関数とは、引数のタプルを受け取り、戻り値を返す、または適切な値が返せない場合は例外を投げる、オブジェクトです。
+概念的には等しい関数や演算が、引数の型によって実装がまったく異なる、ということはよくあります。
+2つの整数を足すことと、2つの浮動小数点数を足すことは、全く異なるし、整数に浮動小数点数を足すこととも異なります。
+実装が違っていても、これらの操作はすべて、一般的な概念の「足し算」に当てはまります。
+したがって、Juliaでは、これらの挙動はすべて1つのオブジェクト「`+`関数」に属します。
 
+
+
+```@raw html
+<!--
 To facilitate using many different implementations of the same concept smoothly, functions need
 not be defined all at once, but can rather be defined piecewise by providing specific behaviors
 for certain combinations of argument types and counts. A definition of one possible behavior for
@@ -20,7 +34,20 @@ tuple of arguments, the most specific method applicable to those arguments is ap
 overall behavior of a function is a patchwork of the behaviors of its various method definitions.
 If the patchwork is well designed, even though the implementations of the methods may be quite
 different, the outward behavior of the function will appear seamless and consistent.
+-->
+```
+同じ概念の異なる多くの実装を、円滑に利用するためには、関数すべてを一度に定義する必要はなくて、引数の型と個数の組み合わせごとに、特定の動作を指定して、区分的に定義できます。
+こうした関数の、とるかもしれない１つの動作の定義は、**メソッド**と呼ばれます。
+ここまでで例示した関数は、単一のメソッドで定義されたものだけで、すべての型の引数に適用可能です。
+しかし、メソッド定義のシグネチャに、型注釈をつけると、引数の型と数を指定でき、複数のメソッド定義を与えることができます。
+関数が特定の引数の組に適用されるとき、それらの引数に適用可能なものから最も特化したメソッドが適用されます。
+したがって、関数の全体的な動作は、さまざまなメソッド定義の動作のパッチワークです。
+パッチワークがうまく設計されていれば、メソッドの実装がかなり異なっていても、外側からは関数の動作は継ぎ目なく一貫しているように見えます。
 
+
+
+```@raw html
+<!--
 The choice of which method to execute when a function is applied is called *dispatch*. Julia allows
 the dispatch process to choose which of a function's methods to call based on the number of arguments
 given, and on the types of all of the function's arguments. This is different than traditional
@@ -34,40 +61,87 @@ the addition operation in `x + y` belong to `x` any more than it does to `y`? Th
 of a mathematical operator generally depends on the types of all of its arguments. Even beyond
 mathematical operations, however, multiple dispatch ends up being a powerful and convenient paradigm
 for structuring and organizing programs.
+-->
+```
+実行するメソッドを、関数が適用される際に選択することを、**ディスパッチ**と呼ばれます。
+Juliaでは、ディスパッチの過程で、関数のメソッドのどれを呼び出すか、関数のすべての引数の型と個数に基づいて、選択できます。
+これは、従来のオブジェクト指向言語とは異なります。従来のオブジェクト指向言語では、通常は最初の引数のみに基づいてディスパッチが行われ、最初の引数を特別視して引数に見えないような構文を持つものもあります。
+[^ 1]
+関数の、最初の引数だけではなく、すべての引数を使用して、呼び出すメソッドを選択することは、[多重ディスパッチ](https://en.wikipedia.org/wiki/)として知られています。
+多重ディスパッチは特に数学のコードで有用です。演算がどの引数に、より「属している」かと不自然なことを考えても、意味がないからです。`x + y` の式の中の足し算は、 `x` に `y`よりも属してると思いますか？
+数学的演算子の実装は、一般には、すべての引数の型に依存しています。
+しかし、数学的な操作以外でも、多重ディスパッチは、プログラムの構築し組織化する強力で便利なパラダイムです。
 
+
+```@raw html
+<!--
 [^1]:
     In C++ or Java, for example, in a method call like `obj.meth(arg1,arg2)`, the object obj "receives"
     the method call and is implicitly passed to the method via the `this` keyword, rather than as
     an explicit method argument. When the current `this` object is the receiver of a method call,
     it can be omitted altogether, writing just `meth(arg1,arg2)`, with `this` implied as the receiving
     object.
+-->
+```
+[^ 1]：例えば、C ++やJavaでは、`obj.meth(arg1,arg2)`のようなメソッドが呼ばれる時は、オブジェクトobjはメソッド呼び出しを「受け取り」、暗黙のうちに`this`キーワードを介して、引数だと明示されずに、メソッドに引き渡されます。`this`オブジェクトがメソッド呼び出しのレシーバである場合は省略できます。`meth(arg1,arg2)`と書くだけで、`this`は受け取るオブジェクトを暗示します。
 
-## Defining Methods
+[](## Defining Methods)
+## メソッドの定義
 
+
+```@raw html
+<!--
 Until now, we have, in our examples, defined only functions with a single method having unconstrained
 argument types. Such functions behave just like they would in traditional dynamically typed languages.
 Nevertheless, we have used multiple dispatch and methods almost continually without being aware
 of it: all of Julia's standard functions and operators, like the aforementioned `+` function,
 have many methods defining their behavior over various possible combinations of argument type
 and count.
+-->
+```
+今までの例では、引数に型の制約がない、単一のメソッドしかない関数しか定義していませんでした。
+そのような関数は、従来の動的型付け言語と同じように動作します。
+にもかかわらず、私たちは知らない間に、ほぼ断続的に多重ディスパッチとメソッドを使用してきました。
+前述の`+`関数のような、Juliaの標準的な関数と演算子はすべて、多くのメソッドを持ち、引数の型と個数のさまざまな組み合わせに対して動作が定義されています。
 
+
+
+```@raw html
+<!--
 When defining a function, one can optionally constrain the types of parameters it is applicable
 to, using the `::` type-assertion operator, introduced in the section on [Composite Types](@ref):
+-->
+```
+関数を定義するときには、必要に応じて、[複合型](@ref)に関するセクションで紹介した`::`型表明演算子を使って、適用可能なパラメータの型を、制限することができます。
 
 ```jldoctest fofxy
 julia> f(x::Float64, y::Float64) = 2x + y
 f (generic function with 1 method)
 ```
 
+
+```@raw html
+<!--
 This function definition applies only to calls where `x` and `y` are both values of type
 [`Float64`](@ref):
+-->
+```
+この関数定義は、`x`と`y`の値の型が両方とも[`Float64`](@ref)である呼び出しにだけ、適用されます。
+
 
 ```jldoctest fofxy
 julia> f(2.0, 3.0)
 7.0
 ```
 
+
+```@raw html
+<!--
 Applying it to any other types of arguments will result in a [`MethodError`](@ref):
+-->
+```
+この関数定義を他の型の引数に適用すると、次のような[`MethodError`](@ref)になります。
+
 
 ```jldoctest fofxy
 julia> f(2.0, 3)
@@ -89,12 +163,23 @@ julia> f("2.0", "3.0")
 ERROR: MethodError: no method matching f(::String, ::String)
 ```
 
+
+```@raw html
+<!--
 As you can see, the arguments must be precisely of type [`Float64`](@ref). Other numeric
 types, such as integers or 32-bit floating-point values, are not automatically converted
 to 64-bit floating-point, nor are strings parsed as numbers. Because `Float64` is a concrete
 type and concrete types cannot be subclassed in Julia, such a definition can only be applied
 to arguments that are exactly of type `Float64`. It may often be useful, however, to write
 more general methods where the declared parameter types are abstract:
+-->
+```
+
+これを見て分かるように、引数はちょうど[`Float64`](@ref)型でなければなりません。
+他の整数や32ビット浮動小数点数などの数値型は、自動的に64ビット浮動小数点数に変換されず、文字列も数字として解析されません。
+`Float64`は具象型で、具象型はJuliaでは、サブクラス化できないので、このような定義はちょうど型が`Float64`の引数のみに適用ができます。
+しかし、宣言するパラメータの型が抽象的な、汎化メソッドを書くと、けっこう役に立つかもしれません。。
+
 
 ```jldoctest fofxy
 julia> f(x::Number, y::Number) = 2x - y
@@ -104,11 +189,23 @@ julia> f(2.0, 3)
 1.0
 ```
 
+
+```@raw html
+<!--
 This method definition applies to any pair of arguments that are instances of [`Number`](@ref).
 They need not be of the same type, so long as they are each numeric values. The problem of
 handling disparate numeric types is delegated to the arithmetic operations in the
 expression `2x - y`.
+-->
+```
+このメソッド定義は[`Number`](@ref)のインスタンスである任意の引数のペアに適用されます。
+それらがそれぞれ数値である限り、同じ型である必要はありません。
+異なる数値型を処理する問題は、式`2x - y`の算術演算に委譲されます。
 
+
+
+```@raw html
+<!--
 To define a function with multiple methods, one simply defines the function multiple times, with
 different numbers and types of arguments. The first method definition for a function creates the
 function object, and subsequent method definitions add new methods to the existing function object.
@@ -118,6 +215,13 @@ behavior for `f` over all pairs of instances of the abstract type `Number` -- bu
 behavior specific to pairs of [`Float64`](@ref) values. If one of the arguments is a 64-bit
 float but the other one is not, then the `f(Float64,Float64)` method cannot be called and
 the more general `f(Number,Number)` method must be used:
+-->
+```
+複数のメソッドを持つ関数を定義するには、単に複数回の関数の定義を、数と型の異なる引数に対して、行うだけです。
+最初のメソッド定義では、関数オブジェクトを作成され、次回以降のメソッド定義では、既存の関数オブジェクトに新しいメソッドが追加されます。
+関数の適用時に、引数の数と型が最も一致するメソッド定義が実行されます。
+したがって、上の2つのメソッド定義が一緒になって、抽象型`Number`のインスタンスのペアすべてに対して`f`の動作を定義しますが、値[`Float64`](@ref)のペアに固有の動作は異なります。
+引数の1つが64ビット浮動小数点数で、もう1つがそうでない場合、この`f(Float64,Float64)`メソッドは呼び出すことができず、より一般的な`f(Number,Number)`メソッドを使用する必要があります。
 
 ```jldoctest fofxy
 julia> f(2.0, 3.0)
@@ -133,6 +237,9 @@ julia> f(2, 3)
 1
 ```
 
+
+```@raw html
+<!--
 The `2x + y` definition is only used in the first case, while the `2x - y` definition is used
 in the others. No automatic casting or conversion of function arguments is ever performed: all
 conversion in Julia is non-magical and completely explicit. [Conversion and Promotion](@ref conversion-and-promotion),
@@ -141,6 +248,15 @@ from magic. [^Clarke61]
 
 For non-numeric values, and for fewer or more than two arguments, the function `f` remains undefined,
 and applying it will still result in a [`MethodError`](@ref):
+-->
+```
+`2x + y`という定義は、最初の場合にだけ使われていますが、`2x - y`という定義が、その他では使われています。
+関数の引数の自動キャストや変換は一度も実行されません。
+Juliaでは、すべての変換は魔法ではなく完全に明示的です。
+しかし、[Conversion and Promotion]（@ ref conversion-and-promotion）では、十分に高度な技術をうまく使うと、魔法と区別できないほどになることを示しています。[^ Clarke61]
+
+数値以外の値や2つ以上の引数の場合、関数`f`は未定義のままであり、そのまま適用すると次のように[`MethodError`](@ref)がおこります。
+
 
 ```jldoctest fofxy
 julia> f("foo", 3)
@@ -155,16 +271,30 @@ Closest candidates are:
   f(!Matched::Number, !Matched::Number) at none:1
 ```
 
+
+```@raw html
+<!--
 You can easily see which methods exist for a function by entering the function object itself in
 an interactive session:
+-->
+```
+対話セッションで関数オブジェクト自体を入力すると、関数にどんなメソッドが存在するかを簡単に確認できます。
+
 
 ```jldoctest fofxy
 julia> f
 f (generic function with 2 methods)
 ```
 
+
+```@raw html
+<!--
 This output tells us that `f` is a function object with two methods. To find out what the signatures
 of those methods are, use the [`methods()`](@ref) function:
+-->
+```
+この出力は、`f`が2つのメソッドを持つ関数オブジェクトであることを示しています。
+これらのメソッドのシグネチャを調べるには、[`methods()`](@ref)関数を使用します。
 
 ```julia-repl
 julia> methods(f)
@@ -173,6 +303,10 @@ f(x::Float64, y::Float64) in Main at none:1
 f(x::Number, y::Number) in Main at none:1
 ```
 
+
+```@raw html
+<!--
+
 which shows that `f` has two methods, one taking two `Float64` arguments and one taking arguments
 of type `Number`. It also indicates the file and line number where the methods were defined: because
 these methods were defined at the REPL, we get the apparent line number `none:1`.
@@ -180,6 +314,16 @@ these methods were defined at the REPL, we get the apparent line number `none:1`
 In the absence of a type declaration with `::`, the type of a method parameter is `Any` by default,
 meaning that it is unconstrained since all values in Julia are instances of the abstract type
 `Any`. Thus, we can define a catch-all method for `f` like so:
+-->
+```
+
+すると表示されるのは、`f`が二つのメソッドを持っていて、一方は2つの`Float64`の引数を取り、他方は型が`Number`の引数を取ることです。
+また、メソッドが定義されたファイルと行番号も表示されます。
+これらのメソッドはREPLで定義されているため、見かけの行番号`none:1`が表示されます。
+
+`::`による型宣言がない場合、メソッドのパラメータの型はデフォルトでは`Any`であり、Juliaのすべての値が抽象型`Any`のインスタンスであるため、制約がないことを意味しています 。
+したがって、`f`の全捕捉メソッドを以下のように定義することができます。
+
 
 ```jldoctest fofxy
 julia> f(x,y) = println("Whoa there, Nelly.")
@@ -189,12 +333,20 @@ julia> f("foo", 1)
 Whoa there, Nelly.
 ```
 
+
+```@raw html
+<!--
 This catch-all is less specific than any other possible method definition for a pair of parameter
 values, so it will only be called on pairs of arguments to which no other method definition applies.
 
 Although it seems a simple concept, multiple dispatch on the types of values is perhaps the single
 most powerful and central feature of the Julia language. Core operations typically have dozens
 of methods:
+-->
+```
+この全捕捉は、どの引数のペアに対する他のメソッド定義よりも特化していないため、他のメソッド定義が適用されない引数のペアに対してのみ呼び出されます。
+
+単純な考え方のように見えますが、値型に対する多重ディスパッチは、おそらくJulia言語の最も強力で中心的な機能です。中心となる演算には通常数十種類のメソッドがあります。
 
 ```julia-repl
 julia> methods(+)
@@ -220,14 +372,27 @@ julia> methods(+)
 +(a, b, c, xs...) at operators.jl:119
 ```
 
+
+```@raw html
+<!--
 Multiple dispatch together with the flexible parametric type system give Julia its ability to
 abstractly express high-level algorithms decoupled from implementation details, yet generate efficient,
 specialized code to handle each case at run time.
+-->
+```
+多重ディスパッチと柔軟なパラメトリック型システムによって、Juliaに与えられた能力は、高水準のアルゴリズムを抽象的に表現して、実装の詳細から切り離し、実行時に各ケースに特化して処理する効率的なコードを生成することです。
 
-## [Method Ambiguities](@id man-ambiguities)
+[](## [Method Ambiguities](@id man-ambiguities))
+## [メソッドの曖昧さ](@id man-ambiguities)
 
+
+```@raw html
+<!--
 It is possible to define a set of function methods such that there is no unique most specific
 method applicable to some combinations of arguments:
+-->
+```
+ある種の引数の組み合わせに対しては、最も特化するメソッドが一意に定まらない、関数メソッドの組み合わせに、定義がなってしまう可能性があります。
 
 ```jldoctest gofxy
 julia> g(x::Float64, y) = 2x + y
@@ -247,10 +412,19 @@ ERROR: MethodError: g(::Float64, ::Float64) is ambiguous.
 [...]
 ```
 
+
+```@raw html
+<!--
 Here the call `g(2.0, 3.0)` could be handled by either the `g(Float64, Any)` or the `g(Any, Float64)`
 method, and neither is more specific than the other. In such cases, Julia raises a [`MethodError`](@ref)
 rather than arbitrarily picking a method. You can avoid method ambiguities by specifying an appropriate
 method for the intersection case:
+-->
+```
+ここでの関数呼び出し`g(2.0, 3.0)`は、`g(Float64, Any)`と`g(Any, Float64)` のメソッドによって処理可能ですが、どちらがより特化しているかは決められません。
+このような場合、Juliaは勝手にメソッドを選択せずに、[`MethodError`](@ref)を発生させます。 
+共通する場合に特化したメソッドを指定することで、メソッドの曖昧さをなくすことができます。
+
 
 ```jldoctest gofxy
 julia> g(x::Float64, y::Float64) = 2x + 2y
@@ -266,15 +440,33 @@ julia> g(2.0, 3.0)
 10.0
 ```
 
+
+```@raw html
+<!--
 It is recommended that the disambiguating method be defined first, since otherwise the ambiguity
 exists, if transiently, until the more specific method is defined.
 
 In more complex cases, resolving method ambiguities involves a certain
 element of design; this topic is explored further [below](@ref man-method-design-ambiguities).
+-->
+```
+曖昧さのないメソッドを最初に定義することが推奨されます。というのも、一時的にせよ、より特化したメソッドが定義されるまで、曖昧さが残るからです。
 
-## Parametric Methods
+より複雑なケースでは、メソッドの曖昧さを解決するには一定の設計要素が必要になります。この話題は[below]（@ ref man-method-design-ambiguities）をさらに詳しく解説しています。
 
+[](## Parametric Methods)
+## パラメトリックメソッド
+
+
+
+```@raw html
+<!--
 Method definitions can optionally have type parameters qualifying the signature:
+-->
+```
+
+メソッド定義で、任意で型パラメータをつけて、シグネチャを細かく指定することができます。
+
 
 ```jldoctest same_typefunc
 julia> same_type(x::T, y::T) where {T} = true
@@ -284,10 +476,19 @@ julia> same_type(x,y) = false
 same_type (generic function with 2 methods)
 ```
 
+
+```@raw html
+<!--
 The first method applies whenever both arguments are of the same concrete type, regardless of
 what type that is, while the second method acts as a catch-all, covering all other cases. Thus,
 overall, this defines a boolean function that checks whether its two arguments are of the same
 type:
+-->
+```
+第1のメソッドは、両方の引数が同じ具象型であれば、どんな型であれ適用されます。第2のメソッドは他のすべての場合に渡る全捕捉として働きます。
+したがって、これは全体として、2つの引数が同じ型であるかどうかを検査するブール関数の定義になっています。
+
+
 
 ```jldoctest same_typefunc
 julia> same_type(1, 2)
@@ -309,6 +510,9 @@ julia> same_type(Int32(1), Int64(2))
 false
 ```
 
+
+```@raw html
+<!--
 Such definitions correspond to methods whose type signatures are `UnionAll` types
 (see [UnionAll Types](@ref)).
 
@@ -317,6 +521,13 @@ in Julia. Method type parameters are not restricted to being used as the types o
 they can be used anywhere a value would be in the signature of the function or body of the function.
 Here's an example where the method type parameter `T` is used as the type parameter to the parametric
 type `Vector{T}` in the method signature:
+-->
+```
+
+そのような定義はシグネチャがUnionAll型であるメソッドに対応します([全合併型](@ref) 参照)。
+
+Juliaでは、このようにディスパッチを使って関数の動作を定義するのは、まったく普通であって、慣用的でさえあります。メソッドの型パラメータは、引数の型として使えるだけでなく、関数の本体または関数のシグネチャの、値がある場所であればどこでも使えます。メソッドの型パラメータ`T`が、メソッドのシグネチャのパラメトリック型に対する型パラメータ`Vector{T}`として使用される例を次に示します。
+
 
 ```jldoctest
 julia> myappend(v::Vector{T}, x::T) where {T} = [v..., x]
@@ -347,9 +558,17 @@ Closest candidates are:
   myappend(::Array{T,1}, !Matched::T) where T at none:1
 ```
 
+
+```@raw html
+<!--
 As you can see, the type of the appended element must match the element type of the vector it
 is appended to, or else a [`MethodError`](@ref) is raised. In the following example, the method type parameter
 `T` is used as the return value:
+-->
+```
+ご覧のように、追加する要素の型は、追加されるベクトルの要素の型と一致しなければなりません。でなければ、[`MethodError`](@ref) が生成されます。
+次の例では、メソッドの型パラメータ `T`が戻り値として使用されています。
+
 
 ```jldoctest
 julia> mytypeof(x::T) where {T} = T
@@ -362,8 +581,14 @@ julia> mytypeof(1.0)
 Float64
 ```
 
+
+```@raw html
+<!--
 Just as you can put subtype constraints on type parameters in type declarations (see [Parametric Types](@ref)),
 you can also constrain type parameters of methods:
+-->
+```
+型宣言（[パラメトリック](@ref)型を参照）に出てくる型パラメータにサブタイプ制約を付加できるのと同様に、メソッドの型パラメータも制約することができます。
 
 ```jldoctest
 julia> same_type_numeric(x::T, y::T) where {T<:Number} = true
@@ -394,19 +619,37 @@ julia> same_type_numeric(Int32(1), Int64(2))
 false
 ```
 
+
+```@raw html
+<!--
 The `same_type_numeric` function behaves much like the `same_type` function defined above, but
 is only defined for pairs of numbers.
+-->
+```
+この`same_type_numeric`関数は、以前に定義した関数`same_type`と非常によく似た動作をしますが、数値の組に対してのみ定義されています。
 
+```@raw html
+<!--
 Parametric methods allow the same syntax as `where` expressions used to write types
 (see [UnionAll Types](@ref)).
 If there is only a single parameter, the enclosing curly braces (in `where {T}`) can be omitted,
 but are often preferred for clarity.
 Multiple parameters can be separated with commas, e.g. `where {T, S<:Real}`, or written using
 nested `where`, e.g. `where S<:Real where T`.
+-->
+```
 
-Redefining Methods
+パラメトリックメソッドでは、型の作成に使用される`where`式と同じ構文を使用できます（[全合併型](@ref)を参照）。パラメータが1つしかない場合は、中括弧（`where {T}`）を省略することができますが、わかりやくするために、よく好んでつけられます。複数のパラメータは、例えば、カンマで区切ったり(例`where {T, S<:Real}`)、またはネストされた`where`を使ったりして記述されます。（例`where S<:Real where T`）
+
+
+[](Rdefining Methods)
+
+メソッドの再定義
 ------------------
 
+
+```@raw html
+<!--
 When redefining a method or adding new methods,
 it is important to realize that these changes don't take effect immediately.
 This is key to Julia's ability to statically infer and compile code to run fast,
@@ -414,6 +657,12 @@ without the usual JIT tricks and overhead.
 Indeed, any new method definition won't be visible to the current runtime environment,
 including Tasks and Threads (and any previously defined `@generated` functions).
 Let's start with an example to see what this means:
+-->
+```
+メソッドの再定義や、新しいメソッドの追加は、その変更が即座に反映されない、という認識は重要です。
+これは、Juliaが静的にコードを推論しコンパイルする際に、通常のJITトリックやオーバーヘッドがなくてすむ鍵となります。
+実際、新しいメソッド定義は、タスクおよびスレッド（およびそれ以前に定義された@generated関数）を含め、現在の実行時環境ではまったく見えません。
+これが何を意味するかを例をあげて見てみましょう。
 
 ```julia-repl
 julia> function tryeval()
@@ -434,19 +683,38 @@ julia> newfun()
 1
 ```
 
+
+```@raw html
+<!--
 In this example, observe that the new definition for `newfun` has been created,
 but can't be immediately called.
 The new global is immediately visible to the `tryeval` function,
 so you could write `return newfun` (without parentheses).
 But neither you, nor any of your callers, nor the functions they call, or etc.
 can call this new method definition!
+-->
+```
+この例では、`newfun`の新しい定義は作成されましたが、すぐには呼び出せないことに注意してください。
+新しいグローバルな関数はすぐに`tryeval`関数から見えるので、`return newfun`（カッコなし）と書くことができます。
+しかし、あなたも、呼ぶ関数からも、呼ばれる関数からも、この新しいメソッド定義を呼び出すことはできません！
+[訳注:この文の前後は意味がとれませんでした。]
 
+
+```@raw html
+<!--
 But there's an exception: future calls to `newfun` *from the REPL* work as expected,
 being able to both see and call the new definition of `newfun`.
 
-However, future calls to `tryeval` will continue to see the definition of `newfun` as it was
+However, future calls to `tryeval` will continue to see the definition of `newfun`as it was
 *at the previous statement at the REPL*, and thus before that call to `tryeval`.
+-->
+```
+しかし、例外はあります。`newfun`への **REPLからの**今後の呼び出しは、期待通りに動作し、`newfun`の新しい定義を参照して呼び出すことができます。
 
+しかし、`tryeval`への今後の呼び出しが、参照し続ける`newfun`の定義は、次回`tryeval`を呼び出すまでは**REPLで前回行った**ものです。前回の`tryeval`の呼び出しも同様だったのです。
+
+```@raw html
+<!--
 You may want to try this for yourself to see how it works.
 
 The implementation of this behavior is a "world age counter".
@@ -456,9 +724,27 @@ as a single number, or "world age".
 It also allows comparing the methods available in two worlds just by comparing their ordinal value.
 In the example above, we see that the "current world" (in which the method `newfun()` exists),
 is one greater than the task-local "runtime world" that was fixed when the execution of `tryeval` started.
+-->
+```
+これがどのように動作するかを見るために自身で試してみたいと思うかもしれません。
 
+この行動の実装は「世界の世代のカウンター」です。
+この単調に増加する値は、各メソッド定義の操作を追跡します。
+これにより、「実行時環境から見えるメソッド定義の集合」を、単一の数値「世界世代」として記述することができます。
+また、世代を比較するだけで、2つの世界で利用できるメソッドを比較することもできます。
+上記の例では、メソッド`newfun()`が存在する「現在の世界」が、`tryeval`開始時に設定されたタスクローカルの「実行時の世界」よりも１つ大きいことがわかります。
+
+
+
+```@raw html
+<!--
 Sometimes it is necessary to get around this (for example, if you are implementing the above REPL).
 Fortunately, there is an easy solution: call the function using [`Base.invokelatest`](@ref):
+-->
+```
+場合によってはこれを回避する必要があります（たとえば、上記のREPLを実装している場合など）。
+幸いにも、簡単な解決策があって、[`Base.invokelatest`](@ref)を使って関数を呼び出せば、いいのです。
+
 
 ```jldoctest
 julia> function tryeval2()
@@ -471,15 +757,29 @@ julia> tryeval2()
 2
 ```
 
+
+```@raw html
+<!--
 Finally, let's take a look at some more complex examples where this rule comes into play.
 Define a function `f(x)`, which initially has one method:
+-->
+```
+最後に、このルールが適用されるより複雑な例を、いくつか見てみましょう。最初は1つのメソッドを持つ関数`f(x)`を定義します。
+
 
 ```jldoctest redefinemethod
 julia> f(x) = "original definition"
 f (generic function with 1 method)
 ```
 
+
+```@raw html
+<!--
 Start some other operations that use `f(x)`:
+-->
+```
+
+他の`f(x)`を使う操作を開始します。
 
 ```jldoctest redefinemethod
 julia> g(x) = f(x)
@@ -488,7 +788,15 @@ g (generic function with 1 method)
 julia> t = @async f(wait()); yield();
 ```
 
+
+```@raw html
+<!--
 Now we add some new methods to `f(x)`:
+-->
+```
+ここでいくつかの新しいメソッドを`f(x)`に追加します。
+
+
 
 ```jldoctest redefinemethod
 julia> f(x::Int) = "definition for Int"
@@ -498,7 +806,14 @@ julia> f(x::Type{Int}) = "definition for Type{Int}"
 f (generic function with 3 methods)
 ```
 
+
+```@raw html
+<!--
 Compare how these results differ:
+-->
+```
+これらの結果がどのように異なるかを比較します。
+
 
 ```jldoctest redefinemethod
 julia> f(1)
@@ -516,12 +831,19 @@ julia> wait(schedule(t, 1))
 "definition for Int"
 ```
 
-## Parametrically-constrained Varargs methods
+[](## Parametrically-constrained Varargs methods)
 ## パラメトリック制約付き可変引数メソッド
 
+
+```@raw html
+<!--
 Function parameters can also be used to constrain the number of arguments that may be supplied
 to a "varargs" function ([可変引数関数](@ref)).  The notation `Vararg{T,N}` is used to indicate
 such a constraint.  For example:
+-->
+```
+関数のパラメータは、 "varargs"関数([可変引数関数](@ref))が受け取る引数の数を制限するためにも使用できます。
+`Vararg{T,N}`という記法は、そういう制約のために使用われます。例えば：
 
 ```jldoctest
 julia> bar(a,b,x::Vararg{Any,2}) = (a,b,x)
@@ -541,25 +863,48 @@ Closest candidates are:
   bar(::Any, ::Any, ::Any, ::Any) at none:1
 ```
 
+
+```@raw html
+<!--
 More usefully, it is possible to constrain varargs methods by a parameter. For example:
+-->
+```
+さらに便利なことに、パラメータで可変引数メソッドを制約することができます。例えば：
 
 ```julia
 function getindex(A::AbstractArray{T,N}, indexes::Vararg{Number,N}) where {T,N}
 ```
 
+```@raw html
+<!--
 would be called only when the number of `indexes` matches the dimensionality of the array.
+-->
+```
+`indexes`の数が配列の次元の数と一致する場合にのみ呼び出されます。
 
-## Note on Optional and keyword Arguments
-## 省略可能引数とキーワード引数の注意点
+[](## Note on Optional and keyword Arguments)
+## オプション引数とキーワード引数の注意点
 
+
+```@raw html
+<!--
 As mentioned briefly in [関数](@ref man-functions), optional arguments are implemented as syntax for multiple
 method definitions. For example, this definition:
+-->
+```
+[関数]（@ ref man-functions）で簡単に述べたように、オプション引数は複数のメソッドを定義する構文として実装されています。例として、この定義を見てみましょう。
 
 ```julia
 f(a=1,b=2) = a+2b
 ```
 
+
+```@raw html
+<!--
 translates to the following three methods:
+-->
+```
+これは以下の3つのメソッドに変換されます。
 
 ```julia
 f(a,b) = a+2b
@@ -567,30 +912,61 @@ f(a) = f(a,2)
 f() = f(1,2)
 ```
 
+
+```@raw html
+<!--
 This means that calling `f()` is equivalent to calling `f(1,2)`. In this case the result is `5`,
 because `f(1,2)` invokes the first method of `f` above. However, this need not always be the case.
 If you define a fourth method that is more specialized for integers:
+-->
+```
+これは、`f()`の呼び出しと`f(1,2)`の呼び出しは同等なことを意味します。
+この場合、結果は`5`で、`f(1,2)`は最初の`f`メソッドを呼び出すからです。
+しかし、必ずこうする必要はなく、整数に特化した4番目のメソッドを定義した場合は、次のようになります。
+
 
 ```julia
 f(a::Int,b::Int) = a-2b
 ```
 
+
+```@raw html
+<!--
 then the result of both `f()` and `f(1,2)` is `-3`. In other words, optional arguments are tied
 to a function, not to any specific method of that function. It depends on the types of the optional
 arguments which method is invoked. When optional arguments are defined in terms of a global variable,
 the type of the optional argument may even change at run-time.
+-->
+```
+`f()`と`f(1,2)`の結果は両方とも`-3`です。言い換えれば、オプション引数は、その関数の特定のメソッドではなく、関数自体に結び付けられます。オプション引数の型によって、どのメソッドが呼び出されるかが変わります。オプション引数がグローバル変数で定義されている場合、オプション引数の型は実行時に変更されることさえあります。
 
+```@raw html
+<!--
 Keyword arguments behave quite differently from ordinary positional arguments. In particular,
 they do not participate in method dispatch. Methods are dispatched based only on positional arguments,
 with keyword arguments processed after the matching method is identified.
+-->
+```
+キーワード引数は、通常の位置による引数とはまったく異なった動作をします。特に、メソッドディスパッチには加わりません。メソッドは、位置による引数にだけに基づいてディスパッチされ、一致するメソッドが特定された後にキーワード引数が処理されます。
 
-## Function-like objects
+[](## Function-like objects)
+## 関数のようなオブジェクト
 
+
+```@raw html
+<!--
 Methods are associated with types, so it is possible to make any arbitrary Julia object "callable"
 by adding methods to its type. (Such "callable" objects are sometimes called "functors.")
 
 For example, you can define a type that stores the coefficients of a polynomial, but behaves like
 a function evaluating the polynomial:
+-->
+```
+メソッドは型に関連付けられているので、その型にメソッドを追加することで、任意のJuliaオブジェクトを「呼び出し可能」にすることができます。（このような「呼び出し可能な」オブジェクトは、「ファンクタ」と呼ばれることもあります）
+
+たとえば、係数を保持する多項式の型を定義できますが、多項式を評価する関数のように動作します。
+
+
 
 ```jldoctest polynomial
 julia> struct Polynomial{R}
@@ -606,8 +982,14 @@ julia> function (p::Polynomial)(x)
        end
 ```
 
+
+```@raw html
+<!--
 Notice that the function is specified by type instead of by name. In the function body, `p` will
 refer to the object that was called. A `Polynomial` can be used as follows:
+-->
+```
+関数が名前ではなく型によって指定されていることに注意してください。関数本体で`p`は、呼ばれたオブジェクトを参照しています。`Polynomial`は以下のように使います。
 
 ```jldoctest polynomial
 julia> p = Polynomial([1,10,100])
@@ -617,41 +999,82 @@ julia> p(3)
 931
 ```
 
+
+```@raw html
+<!--
 This mechanism is also the key to how type constructors and closures (inner functions that refer
 to their surrounding environment) work in Julia, discussed [later in the manual](@ref constructors-and-conversion).
+-->
+```
 
-## Empty generic functions
+このしくみは、型のコンストラクタとクロージャ（周囲の環境を参照する内部関数）がJuliaでどのように作用するかの鍵でもあります。 [マニュアルの後の方](@ref constructors-and-conversion)で検討します。
 
+[](## Empty generic functions)
+## 空の汎化関数
+
+
+```@raw html
+<!--
 Occasionally it is useful to introduce a generic function without yet adding methods. This can
 be used to separate interface definitions from implementations. It might also be done for the
 purpose of documentation or code readability. The syntax for this is an empty `function` block
 without a tuple of arguments:
+-->
+```
+
+まだなにもメソッドを追加しない状態で、汎化関数を導入すると便利になる時があります。これは、インタフェースの定義を実装から分離するために使えます。また、文書化したり、コードの読みやすくしたりするためにもできます。この構文は、引数のタプルがない空の関数のブロックです。
 
 ```julia
 function emptyfunc
 end
 ```
 
-## [Method design and the avoidance of ambiguities](@id man-method-design-ambiguities)
+[](## [Method design and the avoidance of ambiguities](@id man-method-design-ambiguities))
+## [メソッドの設計と曖昧さの回避](@id man-method-design-ambiguities)
 
+
+```@raw html
+<!--
 Julia's method polymorphism is one of its most powerful features, yet
 exploiting this power can pose design challenges.  In particular, in
 more complex method hierarchies it is not uncommon for
 [ambiguities](@ref man-ambiguities) to arise.
+-->
+```
+Juliaのメソッドの多相性は、最も強力な機能の1つですが、この力を利用すると、設計上の困難が生じる可能性があります。
+特に、よりメソッドの階層が複雑なときは、[曖昧さ](@ref man-ambiguities) が発生することは珍しくありません。
 
+
+
+```@raw html
+<!--
 Above, it was pointed out that one can resolve ambiguities like
+-->
+```
+
+以前、以下のように曖昧さを解決できると指摘しましたが
+
 
 ```julia
 f(x, y::Int) = 1
 f(x::Int, y) = 2
 ```
 
+
+```@raw html
+<!--
 by defining a method
+-->
+```
+メソッドを定義することによって
 
 ```julia
 f(x::Int, y::Int) = 3
 ```
 
+
+```@raw html
+<!--
 This is often the right strategy; however, there are circumstances
 where following this advice blindly can be counterproductive. In
 particular, the more methods a generic function has, the more
@@ -660,38 +1083,77 @@ get more complicated than this simple example, it can be worth your
 while to think carefully about alternative strategies.
 
 Below we discuss particular challenges and some alternative ways to resolve such issues.
+-->
+```
 
-### Tuple and NTuple arguments
+これが正しい戦略となる場合はよくでてきます。しかし、この助言に盲従すると、非生産的になる可能性があります。
+特に、汎化関数のメソッドが多くなればなるほど、あいまいになる可能性が増します。
+メソッドの階層がこの単純な例よりも複雑ならば、代替となる戦略も注意深く検討する価値があります。
 
+以下では、特定の課題と、その問題を解決するための代替方法について説明します。
+
+[](### Tuple and NTuple arguments)
+### タプルとNタプル引数
+
+
+```@raw html
+<!--
 `Tuple` (and `NTuple`) arguments present special challenges. For example,
+-->
+```
+`Tuple`（および`NTuple`）の引数には、特殊な課題があります。例えば、
 
 ```julia
 f(x::NTuple{N,Int}) where {N} = 1
 f(x::NTuple{N,Float64}) where {N} = 2
 ```
 
+
+```@raw html
+<!--
 are ambiguous because of the possibility that `N == 0`: there are no
 elements to determine whether the `Int` or `Float64` variant should be
 called. To resolve the ambiguity, one approach is define a method for
 the empty tuple:
+-->
+```
+`N == 0`の可能性があるため、曖昧です。`Int`と`Float64`のどちらを呼び出すべきか、決める要素がありません。
+この曖昧さを解決するには、空のタプルに対してメソッドを定義するという方法があります。
+
 
 ```julia
 f(x::Tuple{}) = 3
 ```
 
+
+```@raw html
+<!--
 Alternatively, for all methods but one you can insist that there is at
 least one element in the tuple:
+-->
+```
+
+あるいは、1つのメソッドを除いた、すべてのメソッドに対して、少なくとも1つの要素がタプルにあるような定義ができます。
+
 
 ```julia
 f(x::NTuple{N,Int}) where {N} = 1           # this is the fallback
 f(x::Tuple{Float64, Vararg{Float64}}) = 2   # this requires at least one Float64
 ```
 
-### [Orthogonalize your design](@id man-methods-orthogonalize)
+[](### [Orthogonalize your design](@id man-methods-orthogonalize))
+### [設計の直交化](@id man-methods-orthogonalize)
 
+
+```@raw html
+<!--
 When you might be tempted to dispatch on two or more arguments,
 consider whether a "wrapper" function might make for a simpler
 design. For example, instead of writing multiple variants:
+-->
+```
+
+ディスパッチに2つ以上の引数を使いたい場合は、「ラッパー」関数を使うと、単純な設計になるかどうかを検討してください。たとえば、複数のメソッドを記述する代わりに
 
 ```julia
 f(x::A, y::A) = ...
@@ -700,102 +1162,195 @@ f(x::B, y::A) = ...
 f(x::B, y::B) = ...
 ```
 
+
+```@raw html
+<!--
 you might consider defining
+-->
+```
+あなたは、こう定義するかもしれない。
 
 ```julia
 f(x::A, y::A) = ...
 f(x, y) = f(g(x), g(y))
 ```
 
+
+```@raw html
+<!--
 where `g` converts the argument to type `A`. This is a very specific
 example of the more general principle of
 [orthogonal design](https://en.wikipedia.org/wiki/Orthogonality_(programming)),
 in which separate concepts are assigned to separate methods. Here, `g`
 will most likely need a fallback definition
+-->
+```
+この例では、`g`が引数を型`A`に変換します。これは、一般的な原理である[直交設計](https://en.wikipedia.org/wiki/Orthogonality_(programming))のとても具体的な例であり、 メソッドごとに別の概念が割り当てられています。ここで`g`は、おそらくフォールバックの定義が必要です
 
+g（x :: A）= x
 ```julia
 g(x::A) = x
 ```
 
+
+```@raw html
+<!--
 A related strategy exploits `promote` to bring `x` and `y` to a common
 type:
+-->
+```
+関連する戦略として、`昇格`を利用して`x`と`y`を共通の型に変換する、というのもあります。
 
 ```julia
 f(x::T, y::T) where {T} = ...
 f(x, y) = f(promote(x, y)...)
 ```
 
+
+```@raw html
+<!--
 One risk with this design is the possibility that if there is no
 suitable promotion method converting `x` and `y` to the same type, the
 second method will recurse on itself infinitely and trigger a stack
 overflow. The non-exported function `Base.promote_noncircular` can be
 used as an alternative; when promotion fails it will still throw an
 error, but one that fails faster with a more specific error message.
+-->
+```
+この設計のリスクの1つは、 `x`と`y`を同じ型に変換する適切な昇格メソッドがなくて、2番目のメソッドが無限に繰り返し実行され、スタックオーバーフローが発生する可能性があります。
+公開されていない関数`Base.promote_noncircular`を代わりに使用できます。昇格に失敗した場合でもエラーは発生しますが、もっと早く失敗してより具体的なエラーメッセージが表示されます。
 
-### Dispatch on one argument at a time
+[](### Dispatch on one argument at a time)
+### １引数をいちどにディスパッチ
 
-If you need to dispatch on multiple arguments, and there are many
+
+```@raw html
+<!--
+If you need to dispatch on  multiplearguments, and there are many
 fallbacks with too many combinations to make it practical to define
 all possible variants, then consider introducing a "name cascade"
 where (for example) you dispatch on the first argument and then call
 an internal method:
+-->
+```
+複数の引数にディスパッチする必要があり、メソッドの組み合わせが多すぎて、フォールバックを現実的には定義しきれない場合は、「名前のカスケード」（たとえば）最初の引数にディスパッチしてから内部的なメソッドを呼び出す）の導入を検討します。
+
 
 ```julia
 f(x::A, y) = _fA(x, y)
 f(x::B, y) = _fB(x, y)
 ```
 
+
+```@raw html
+<!--
 Then the internal methods `_fA` and `_fB` can dispatch on `y` without
 concern about ambiguities with each other with respect to `x`.
+-->
+```
 
+そうすれば、内部メソッドの `_fA`と`_fB`は、`x`に関しては曖昧さを気にせずに、`y`に対してディスパッチできます。
+
+
+```@raw html
+<!--
 Be aware that this strategy has at least one major disadvantage: in
 many cases, it is not possible for users to further customize the
 behavior of `f` by defining further specializations of your exported
 function `f`. Instead, they have to define specializations for your
 internal methods `_fA` and `_fB`, and this blurs the lines between
 exported and internal methods.
+-->
+```
+この戦略には、少なくとも1つの重要な欠点があることに注意してください。
+多くの場合、公開した関数`f`のさらに限定した定義するようなカスタマイズをユーザーがすることはできません。
+代わりに、彼らはあなたの内部メソッドの`_fA`と`_fB`の特殊化を定義する必要があり、これは、公開した関数と内部メソッドの境界がぼやけます。
 
-### Abstract containers and element types
+[](### Abstract containers and element types)
+### 抽象コンテナと要素の型
 
+
+```@raw html
+<!--
 Where possible, try to avoid defining methods that dispatch on
 specific element types of abstract containers. For example,
+-->
+```
+可能であれば、抽象型コンテナに特定の要素型でディスパッチするようなメソッドを定義しないでください。例えば、
+
+
 
 ```julia
 -(A::AbstractArray{T}, b::Date) where {T<:Date}
-```
+```が
 
+```@raw html
+<!--
 generates ambiguities for anyone who defines a method
+-->
+```
+この場合、メソッドを定義しようとすると曖昧さが生じます。
 
 ```julia
 -(A::MyArrayType{T}, b::T) where {T}
 ```
 
+
+```@raw html
+<!--
 The best approach is to avoid defining *either* of these methods:
 instead, rely on a generic method `-(A::AbstractArray, b)` and make
 sure this method is implemented with generic calls (like `similar` and
 `-`) that do the right thing for each container type and element type
 *separately*. This is just a more complex variant of the advice to
 [orthogonalize](@ref man-methods-orthogonalize) your methods.
+-->
+```
+最良の方法は、これらのメソッドの**いずれかを**定義することを避けることです。
+代わりに、汎化メソッドの`-(A::AbstractArray, b)`に依存して、このメソッドが各コンテナ型や要素の型ごとに**別々に**適切なことを行う汎化呼び出し（`similar`や `-`など）で 実装されていることを確認します。
+これはメソッドを[直交化]（@ ref man-methods-orthogonalize）する助言のちょっと複雑な変種です。
 
+```@raw html
+<!--
 When this approach is not possible, it may be worth starting a
 discussion with other developers about resolving the ambiguity; just
 because one method was defined first does not necessarily mean that it
 can't be modified or eliminated.  As a last resort, one developer can
 define the "band-aid" method
+-->
+```
+このアプローチが不可能な場合、曖昧さを解決するために他の開発者と議論を始める価値があります。
+最初に1つのメソッドが定義されているからといって、必ずしもそのメソッドを変更や削除できないわけではないからです。
+最後の手段として、1人の開発者が「救済」メソッドを定義するという手があります。
+
 
 ```julia
 -(A::MyArrayType{T}, b::Date) where {T<:Date} = ...
 ```
 
+
+```@raw html
+<!--
 that resolves the ambiguity by brute force.
+-->
+```
+力技で、曖昧さを解決しています。
 
-### Complex method "cascades" with default arguments
+[](### Complex method "cascades" with default arguments)
+### 複雑なメソッドに"多段的に"デフォルト引数を使う
 
+
+```@raw html
+<!--
 If you are defining a method "cascade" that supplies defaults, be
 careful about dropping any arguments that correspond to potential
 defaults. For example, suppose you're writing a digital filtering
 algorithm and you have a method that handles the edges of the signal
 by applying padding:
+-->
+```
+"多段的に"デフォルト値を設定するメソッドを定義する場合、ありうるデフォルト値に対応する引数を見落とさないように注意してください。たとえば、デジタルフィルタリングアルゴリズムを作成していて、信号のエッジをパディングを適用して処理する方法があるとします。
+
 
 ```julia
 function myfilter(A, kernel, ::Replicate)
@@ -804,15 +1359,29 @@ function myfilter(A, kernel, ::Replicate)
 end
 ```
 
+
+```@raw html
+<!--
 This will run afoul of a method that supplies default padding:
+-->
+```
+これは、デフォルトのパディングを行うメソッドと衝突します：
 
 ```julia
 myfilter(A, kernel) = myfilter(A, kernel, Replicate()) # replicate the edge by default
 ```
 
+
+```@raw html
+<!--
 Together, these two methods generate an infinite recursion with `A` constantly growing bigger.
 
 The better design would be to define your call hierarchy like this:
+-->
+```
+これらの2つのメソッドは、一緒になって、常に大きくなる`A`の無限再帰を生成します。
+
+より良い設計は、次のように呼び出しの階層を定義することです。
 
 ```julia
 struct NoPad end  # indicate that no padding is desired, or that it's already applied
@@ -831,10 +1400,22 @@ function myfilter(A, kernel, ::NoPad)
 end
 ```
 
+
+```@raw html
+<!--
 `NoPad` is supplied in the same argument position as any other kind of
 padding, so it keeps the dispatch hierarchy well organized and with
 reduced likelihood of ambiguities. Moreover, it extends the "public"
 `myfilter` interface: a user who wants to control the padding
 explicitly can call the `NoPad` variant directly.
+-->
+```
+`NoPad`は、他の種類のパディングと同じ引数の位置で指定されているため、ディスパッチの階層を整理しやすく、曖昧になる可能性が低くなります。さらに、"パブリック"の`myfilter`インターフェースを拡張します。パディングを明示的にコントロールしたいユーザーは、`NoPad`のメソッドを直接呼び出すことができます。
 
+
+
+```@raw html
+<!--
 [^Clarke61]: Arthur C. Clarke, *Profiles of the Future* (1961): Clarke's Third Law.
+-->
+```

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -1,5 +1,9 @@
-# [Modules](@id modules)
+[](# [Modules](@id modules))
+# [モジュール](@id modules)
 
+
+```@raw html
+<!--
 Modules in Julia are separate variable workspaces, i.e. they introduce a new global scope. They
 are delimited syntactically, inside `module Name ... end`. Modules allow you to create top-level
 definitions (aka global variables) without worrying about name conflicts when your code is used
@@ -8,6 +12,16 @@ are visible (via importing), and specify which of your names are intended to be 
 
 The following example demonstrates the major features of modules. It is not meant to be run, but
 is shown for illustrative purposes:
+-->
+```
+Juliaのモジュールは独立した変数のワークスペースで、新しいグローバルスコープが導入されます。
+モジュールは`module Name ... end`のなかに構文的に区切られます。
+モジュールを使うと、(グローバル変数として知られる)最上位の定義を行うことできて、自分のコードを他の誰かのコードと一緒に使っても、名前の競合を心配しなくてすみます。
+モジュール内では、他のモジュールのどの名前を（インポートして）参照するかを制御したり、
+自分のモジュールのどの名前を（エクスポートして）公開するかを指定することができます。
+
+次の例は、モジュールの主な機能を示しています。
+これは実行用ではなく、説明用途のものです。
 
 ```julia
 module MyModule
@@ -32,18 +46,42 @@ show(io::IO, a::MyType) = print(io, "MyType $(a.x)")
 end
 ```
 
+
+```@raw html
+<!--
 Note that the style is not to indent the body of the module, since that would typically lead to
 whole files being indented.
 
 This module defines a type `MyType`, and two functions. Function `foo` and type `MyType` are exported,
 and so will be available for importing into other modules.  Function `bar` is private to `MyModule`.
+-->
+```
+表記スタイル上の注意点は、モジュールの本体は字下げすべきではないことでしょう。
+これは字下げをすると、通常ファイル全体を字下げすることになってしまいがちだからです。
 
+このモジュールでは、`MyType`という型と2つの関数が定義されています。
+関数`foo`と型`MyType`はエクスポートされているので、他のモジュールにインポートして利用することができます。
+`bar`は`MyModule`内でプライベートな関数です。
+
+
+
+```@raw html
+<!--
 The statement `using Lib` means that a module called `Lib` will be available for resolving names
 as needed. When a global variable is encountered that has no definition in the current module,
 the system will search for it among variables exported by `Lib` and import it if it is found there.
 This means that all uses of that global within the current module will resolve to the definition
 of that variable in `Lib`.
+-->
+```
 
+`using Lib`と宣言すると、必要に応じて`Lib`というモジュールを名前の解決に利用できます。
+グローバル変数が現在のモジュールで定義されていない場合、`Lib`でエクスポートされている変数の中から検索し、見つかった場合はインポートします。
+これは、グローバル変数を現在のモジュール内で使った場合はすべて、`Lib`内の同名の変数の定義によって解決されることを意味します。
+
+
+```@raw html
+<!--
 The statement `using BigLib: thing1, thing2` is a syntactic shortcut for `using BigLib.thing1, BigLib.thing2`.
 
 The `import` keyword supports all the same syntax as `using`, but only operates on a single name
@@ -52,18 +90,48 @@ from `using` in that functions must be imported using `import` to be extended wi
 
 In `MyModule` above we wanted to add a method to the standard `show` function, so we had to write
 `import Base.show`. Functions whose names are only visible via `using` cannot be extended.
+-->
+```
+`using BigLib: thing1, thing2`という文は`using BigLib.thing1, BigLib.thing2`の簡易構文です。
 
+`import`キーワードは`using`と同じ構文で利用可能ですが、一度に一つの名前にしか使えません。
+`using`のようにモジュール全体を探索対象に加えることはできません。
+インポートした関数を新しいメソッドで拡張したい時は、必ず`import`を使う必要がある点も、`using`と`import`の相違点です。
+
+上記の`MyModule`で、標準的な`show`関数にメソッドを追加したい場合は`import Base.show`と書かなければなりません。
+`using`を通じてでしか名前を参照できない関数は、拡張することはできません。
+
+
+
+```@raw html
+<!--
 The keyword `importall` explicitly imports all names exported by the specified module, as if
 `import` were individually used on all of them.
 
 Once a variable is made visible via `using` or `import`, a module may not create its own variable
 with the same name. Imported variables are read-only; assigning to a global variable always affects
 a variable owned by the current module, or else raises an error.
+-->
+```
+キーワード`importall`を明示的に使うと、指定したモジュールでエクスポートされているすべての名前をインポートするので、
+`import`を使って個々にすべてをインポートするのと同じ効果があります。
 
-## Summary of module usage
+`using`や`import`を通じて、変数がいったん参照可能になると、同じ名前の変数をそのモジュールでは作成できません。
+インポートされた変数は読み取り専用です。
+グローバル変数への代入は、常に現在のモジュールに所属する変数に対して行われるので、そうでなければエラーが発生します。
 
+[](## Summary of module usage)
+## モジュールの用法のまとめ
+
+
+```@raw html
+<!--
 To load a module, two main keywords can be used: `using` and `import`. To understand their differences,
 consider the following example:
+-->
+```
+モジュールのロードには、主に二つのキーワード`using`と`import`を使用することができます。
+この違いを理解するために、次の例を考えましょう。
 
 ```julia
 module MyModule
@@ -77,10 +145,19 @@ p() = "p"
 end
 ```
 
+
+```@raw html
+<!--
 In this module we export the `x` and `y` functions (with the keyword `export`), and also have
 the non-exported function `p`. There are several different ways to load the Module and its inner
 functions into the current workspace:
+-->
+```
+このモジュールには、（キーワード`export`を使って）エクスポートしている関数`x`,`y`と、エクスポートしていない関数`p`があります。
+モジュールをロードして、その内部の関数を、現在のワークスペースに導入するには、いくつかの方法があります。
 
+```@raw html
+<!--
 | Import Command                  | What is brought into scope                                                      | Available for method extension              |
 |:------------------------------- |:------------------------------------------------------------------------------- |:------------------------------------------- |
 | `using MyModule`                | All `export`ed names (`x` and `y`), `MyModule.x`, `MyModule.y` and `MyModule.p` | `MyModule.x`, `MyModule.y` and `MyModule.p` |
@@ -90,11 +167,31 @@ functions into the current workspace:
 | `import MyModule.x, MyModule.p` | `x` and `p`                                                                     | `x` and `p`                                 |
 | `import MyModule: x, p`         | `x` and `p`                                                                     | `x` and `p`                                 |
 | `importall MyModule`            | All `export`ed names (`x` and `y`)                                              | `x` and `y`                                 |
+-->
+```
+| インポートするコマンド                 | スコープに導入されるもの                                                     | メソッドの拡張に利用可能なもの              |
+|:------------------------------- |:------------------------------------------------------------------------------- |:------------------------------------------- |
+| `using MyModule`                | `エクスポート`されたすべての名前 (`x`と`y`), `MyModule.x`, `MyModule.y`,`MyModule.p` | `MyModule.x`, `MyModule.y`,`MyModule.p` |
+| `using MyModule.x, MyModule.p`  | `x`と`p`                                                                     |                                             |
+| `using MyModule: x, p`          | `x`と`p`                                                                     |                                             |
+| `import MyModule`               | `MyModule.x`, `MyModule.y`,`MyModule.p`                                     | `MyModule.x`, `MyModule.y`,`MyModule.p` |
+| `import MyModule.x, MyModule.p` | `x`と`p`                                                                     | `x`と`p`                                |
+| `import MyModule: x, p`         | `x`と`p`                                                                     | `x`と`p`                                 |
+| `importall MyModule`            | `エクスポート`されたすべての名前 (`x`と`y`)                                              | `x`と`p`                                |
 
-### Modules and files
+[](### Modules and files)
+### モジュールとファイル
 
+
+```@raw html
+<!--
 Files and file names are mostly unrelated to modules; modules are associated only with module
 expressions. One can have multiple files per module, and multiple modules per file:
+-->
+```
+ファイルやファイル名は、モジュールとはほとんど無関係です。
+モジュールと関連するのは、モジュール式だけです。
+1つのモジュールが複数のファイルにまたがったり、1つのファイルに複数のモジュールを入れたりすることができます。
 
 ```julia
 module Foo
@@ -105,9 +202,19 @@ include("file2.jl")
 end
 ```
 
+
+```@raw html
+<!--
 Including the same code in different modules provides mixin-like behavior. One could use this
 to run the same code with different base definitions, for example testing code by running it with
 "safe" versions of some operators:
+-->
+```
+異なるモジュールに同じコードを組み込むと、mixinのような動作を実現できます。
+これを利用して、同じコードでも基本の定義を変えて実行することができます。
+たとえば、演算子を「安全な」バージョンに変えてコードを検査する場合などがあります。
+
+
 
 ```julia
 module Normal
@@ -120,8 +227,12 @@ include("mycode.jl")
 end
 ```
 
-### Standard modules
+[](### Standard modules)
+### 標準モジュール
 
+
+```@raw html
+<!--
 There are three important standard modules: Main, Core, and Base.
 
 Main is the top-level module, and Julia starts with Main set as the current module.  Variables
@@ -133,15 +244,38 @@ without those definitions.
 
 Base is the standard library (the contents of base/). All modules implicitly contain `using Base`,
 since this is needed in the vast majority of cases.
+-->
+```
+3つの重要な標準モジュールがあります。
+Mainモジュール、Coreモジュール、Baseモジュールです。
 
-### Default top-level definitions and bare modules
+Mainは最上位のモジュールであり、JuliaはMainを現在のモジュールに設定することから開始します。
+プロンプトで定義された変数はMainに格納され、Mainの変数は`whos()`を使って列挙できます。
 
+Coreには、言語に"組み込まれている"と考えてよいすべての識別子、つまりライブラリではなく言語の核の一部が含まれています。
+これらの定義がないと何もできないので、すべてのモジュールには暗黙的な`using Core`の宣言が含まれます。
+
+Baseは標準ライブラリ（base/の中身）です。
+これは大抵の場合に必要となるので、すべてのモジュールには暗黙的な`using Base`の宣言が含まれます。
+ 
+[](### Default top-level definitions and bare modules)
+### デフォルトの最上位の定義とベアモジュール
+
+
+```@raw html
+<!--
 In addition to `using Base`, modules also automatically contain a definition of the `eval` function,
 which evaluates expressions within the context of that module.
 
 If these default definitions are not wanted, modules can be defined using the keyword `baremodule`
 instead (note: `Core` is still imported, as per above). In terms of `baremodule`, a standard
 `module` looks like this:
+-->
+```
+モジュールには、`using Base`のほかに、そのモジュールのコンテキストに沿って式を評価する `eval` 関数の定義が自動的に取り込まれます。
+
+こういったデフォルトの定義が不要の場合は、キーワード `baremodule` を使用してモジュールを定義することができます （注記：前述の`Core` は依然としてインポートされます）。
+ `baremodule`を使って、標準的な`モジュール`の動作を次のように記述できます。
 
 ```
 baremodule Mod
@@ -156,8 +290,11 @@ eval(m,x) = Core.eval(m, x)
 end
 ```
 
-### Relative and absolute module paths
+[](### Relative and absolute module paths)
+### 相対モジュールパスと絶対モジュールパス
 
+```@raw html
+<!--
 Given the statement `using Foo`, the system looks for `Foo` within `Main`. If the module does
 not exist, the system attempts to `require("Foo")`, which typically results in loading code from
 an installed package.
@@ -166,7 +303,14 @@ However, some modules contain submodules, which means you sometimes need to acce
 is not directly available in `Main`. There are two ways to do this. The first is to use an absolute
 path, for example `using Base.Sort`. The second is to use a relative path, which makes it easier
 to import submodules of the current module or any of its enclosing modules:
+-->
+```
+`using Foo`文が記述されている場合、システムは `Main` 内の `Foo` を探索します。 モジュールが存在しない場合、システムは `require("Foo")` を試行し、通常はインストールされたパッケージからコードがロードされます。
 
+しかし、モジュールの中にはサブモジュールが含むものがあり、`Main`から直接利用できないモジュールにアクセスする必要が時折生じます。
+ これを行うには2つの方法があります。
+ 1つ目は `using Base.Sort` などの絶対パスを使用する方法です。
+ 2つ目は相対パスを使用する方法で、現在のモジュールなどサブモジュールを含むモジュールからのインポートが簡単に行えます。
 ```
 module Parent
 
@@ -180,34 +324,75 @@ using .Utils
 end
 ```
 
+
+```@raw html
+<!--
 Here module `Parent` contains a submodule `Utils`, and code in `Parent` wants the contents of
 `Utils` to be visible. This is done by starting the `using` path with a period. Adding more leading
 periods moves up additional levels in the module hierarchy. For example `using ..Utils` would
 look for `Utils` in `Parent`'s enclosing module rather than in `Parent` itself.
 
 Note that relative-import qualifiers are only valid in `using` and `import` statements.
+-->
+```
+ここで、モジュール `Parent` はサブモジュール `Utils` を含み、`Utils` の内容を `Parent` のコードから参照したいとします。
+ これは、`using`の パスをピリオドから始めれば可能です。
+先頭にさらにピリオドを追加すると、モジュール階層のレベルが上がります。
+例えば `using ..Utils` は、 `Parent` 自体ではなく `Parent` を囲むモジュール内で `Utils` を検索します。
 
-### Module file paths
+相対インポート修飾子は、`using` および `import` 文でのみ有効であることに注意してください。
 
+
+[](### Module file paths)
+### モジュールファイルパス
+
+
+```@raw html
+<!--
 The global variable [`LOAD_PATH`](@ref) contains the directories Julia searches for modules when calling
 `require`. It can be extended using [`push!`](@ref):
+-->
+```
+グローバル変数[`LOAD_PATH`](@ref)には、Juliaが`require`を呼び出した時にモジュールを検索するディレクトリが含まれています 。 これは[`push!`](@ref)を使って拡張することができます。
 
 ```julia
 push!(LOAD_PATH, "/Path/To/My/Module/")
 ```
 
+
+```@raw html
+<!--
 Putting this statement in the file `~/.juliarc.jl` will extend [`LOAD_PATH`](@ref) on every Julia startup.
 Alternatively, the module load path can be extended by defining the environment variable `JULIA_LOAD_PATH`.
+-->
+```
+この文を`~/.juliarc.jl`ファイルに書き込むと、Juliaが起動するたびに[`LOAD_PATH`](@ref)が拡張されます。
+また、環境変数`JULIA_LOAD_PATH`を定義して、モジュールのロードパスを拡張することもできます。
 
-### Namespace miscellanea
+[](### Namespace miscellanea)
+### 名前空間に関する雑記
 
+
+```@raw html
+<!--
 If a name is qualified (e.g. `Base.sin`), then it can be accessed even if it is not exported.
 This is often useful when debugging. It can also have methods added to it by using the qualified
 name as the function name. However, due to syntactic ambiguities that arise, if you wish to add
 methods to a function in a different module whose name contains only symbols, such as an operator,
+
 `Base.+` for example, you must use `Base.:+` to refer to it. If the operator is more than one
 character in length you must surround it in brackets, such as: `Base.:(==)`.
+-->
+```
+名前に修飾子をつけると（例えば`Base.sin`）、名前がエクスポートされていなくてもアクセスできます。
+これは、デバッグ時に便利なことがあります。
+また、修飾子のついた関数に対しては、メソッドを追加することもできます。
+しかし、構文上のあいまいさを避けるため、別のモジュールにある、演算子など、名前が記号だけからなる関数（例えば`Base.+`）にメソッドを追加する場合 `Base.:+`のように参照する必要があります。
+演算子が２文字以上の場合は、`Base.:(==)`のよう括弧で囲む必要があります。
 
+
+```@raw html
+<!--
 Macro names are written with `@` in import and export statements, e.g. `import Mod.@mac`. Macros
 in other modules can be invoked as `Mod.@mac` or `@Mod.mac`.
 
@@ -217,9 +402,23 @@ always module-local.
 A variable can be "reserved" for the current module without assigning to it by declaring it as
 `global x` at the top level. This can be used to prevent name conflicts for globals initialized
 after load time.
+-->
+```
+インポート文やエクスポート文の中では、マクロ名は`@`をつけて`import Mod.@mac`のように書きます。
+他のモジュールのマクロは、`Mod.@mac`や`@Mod.mac`のようにして呼び出すことができます。
 
-### Module initialization and precompilation
+`M.x = y`という構文で、別のモジュールのグローバルに代入することはできません。
+グローバル変数の代入は、常にローカルなモジュールで行われます。
 
+変数は、`global x`のように最上位で宣言することによって、代入が行われず、現在のモジュールに対して "予約"することができます。
+これは、ロードの後に初期化されるグローバル変数の名前の競合を防ぐために利用できます。
+
+[](### Module initialization and precompilation)
+### モジュールの初期化とプレコンパイル
+
+
+```@raw html
+<!--
 Large modules can take several seconds to load because executing all of the statements in a module
 often involves compiling a large amount of code. Julia provides the ability to create precompiled
 versions of modules to reduce this time.
@@ -231,7 +430,20 @@ cache files will be stored in `Base.LOAD_CACHE_PATH[1]`. Subsequently, the modul
 recompiled upon `import` whenever any of its dependencies change; dependencies are modules it
 imports, the Julia build, files it includes, or explicit dependencies declared by `include_dependency(path)`
 in the module file(s).
+-->
+```
+大きなモジュールではロードに数秒かかることがありますが、これはモジュール内のすべての文を実行するには、大量のコードのコンパイルが必要になることが多いためです。
+Juliaには、モジュールをプリコンパイルして、この時間を短縮する機能があります。
 
+逐次的にモジュールをプリコンパイルするには、モジュールファイルの先頭に（`module`のはじまる前に）`__precompile__()`を追加します。
+こうすると、はじめてインポートされるときに自動的にコンパイルされます。
+また、手動で`Base.compilecache(modulename)`を呼び出すこともできます。
+その結果できるキャッシュファイルは`Base.LOAD_CACHE_PATH[1]`に保存されます。
+その後、依存のいずれかが変更されると、モジュールはインポートの時に自動的に再コンパイルされます。
+依存とは、インポートするモジュール、Juliaのビルド、インクルードするファイル、または`include_dependency(path)`とモジュールファイルで宣言された明示的な依存のことです。
+
+```@raw html
+<!--
 For file dependencies, a change is determined by examining whether the modification time (mtime)
 of each file loaded by `include` or added explicitly by `include_dependency` is unchanged, or equal
 to the modification time truncated to the nearest second (to accommodate systems that can't copy
@@ -243,7 +455,16 @@ won't recompile those modules, even if their files change or disappear, in order
 incompatibilities between the running system and the precompile cache. If you want to have changes
 to the source reflected in the running system, you should call `reload("Module")` on the module
 you changed, and any module that depended on it in which you want to see the change reflected.
+-->
+```
+依存がファイルの場合、変更を判断するために、`include`によってロードされたファイル、または`include_dependency`によって明示的に追加された各ファイルの変更時刻（mtime）が変更されていないか、または（mtimeを秒未満の精度でコピーできないシステムに対応するため）最も近い秒に切り捨てられた変更時刻に等しいかどうかを調べます。
+また、`require`中の探索ロジックによって選択されたファイルへのパスがプリコンパイル・ファイルを作成したパスと一致するかどうかも考慮されます。
 
+また、現在のプロセスにすでに依存がロードされている場合を考慮し、実行中のシステムとプリコンパイルしたキャッシュに互換性がなくなるのを避けるために、ファイルが変更や削除されても、モジュールを再コンパイルしません。
+実行中のシステムにソースに加えた変更を反映させたい場合は、変更したモジュールやそれに依存しているモジュールを、変更を反映したい場所で、`reload("Module")`のように呼び出す必要があります。
+
+```@raw html
+<!--
 Precompiling a module also recursively precompiles any modules that are imported therein. If you
 know that it is *not* safe to precompile your module (for the reasons described below), you should
 put `__precompile__(false)` in the module file to cause `Base.compilecache` to throw an error
@@ -251,7 +472,17 @@ put `__precompile__(false)` in the module file to cause `Base.compilecache` to t
 
 `__precompile__()` should *not* be used in a module unless all of its dependencies are also using
 `__precompile__()`. Failure to do so can result in a runtime error when loading the module.
+-->
+```
+また、モジュールをプリコンパイルすると、そこにインポートされたモジュールも再帰的にプリコンパイルされます。
+モジュールをプリコンパイルするのが**安全でない**ことが(後述のような理由で)分かっている場合、そのモジュールに`__precompile__(false)`と書く必要があります。そうすると`Base.compilecache`がエラーを投げます（そして他のプリコンパイル済みモジュールにインポートされるのを防ぎます）。
 
+`__precompile__()`はすべての依存が`__precompile__()`を使用していない限り、モジュール内で使用すべきではありません。
+そうしないと、モジュールをロードするときにランタイムエラーが発生する可能性があります。
+
+
+```@raw html
+<!--
 In order to make your module work with precompilation, however, you may need to change your module
 to explicitly separate any initialization steps that must occur at *runtime* from steps that can
 occur at *compile time*.  For this purpose, Julia allows you to define an `__init__()` function
@@ -262,14 +493,36 @@ state for the local machine, which does not need to be – or even should not be
 in the compiled image. It will be called after the module is loaded into a process, including
 if it is being loaded into an incremental compile (`--output-incremental=yes`), but not if it
 is being loaded into a full-compilation process.
+-->
+```
+しかし、モジュールをプリコンパイルしても動作するようにするには、**実行時**の初期化処理と、**コンパイル時**の処理を明確に分離するようにモジュールを変更する必要があるかもしれません。
+こういう用途のために、Juliaには`__init__()`関数が備わっています。
+モジュール内に`__init__()`関数を定義すると、実行時に行うべき初期化処理を実行できます。
+この関数は、（`--output-*`や`__precompile__()`などによる）コンパイル時には呼び出されません。
+もちろん、必要に応じて手動で呼び出すこともできますが、デフォルトでは、この関数はローカルマシンの計算状態を扱うことが想定されているので、コンパイル後のイメージにとりこむ必要はありませんし、とりこむべきでもありません。
+`__init__()`関数はモジュールがプロセスにロードされたあとに呼び出されます。
+これはインクリメンタルコンパイル（`--output-incremental=yes`）でロードされる場合も該当しますが、フルコンパイルプロセスにロードされている場合は該当しません。
 
+
+```@raw html
+<!--
 In particular, if you define a `function __init__()` in a module, then Julia will call `__init__()`
 immediately *after* the module is loaded (e.g., by `import`, `using`, or `require`) at runtime
 for the *first* time (i.e., `__init__` is only called once, and only after all statements in the
 module have been executed). Because it is called after the module is fully imported, any submodules
 or other imported modules have their `__init__` functions called *before* the `__init__` of the
 enclosing module.
+-->
+```
 
+特にモジュール内に、`function __init__()`が定義されている場合は、`__init__()`は（`import`、`using`、`require`などによって）モジュールがロードされた直後の、初めての実行時にJuliaから呼び出されます
+（つまり、モジュール内のすべての文が実行されたあとに、たった一度だけ`__init__`は呼び出されます）。
+`__init__` はモジュールが完全にインポートされた後に呼び出されるため、サブモジュールやその他のインポートされるモジュールにある`__init__`は、それを囲むモジュールの`__init__`の前に呼び出されます。
+
+
+
+```@raw html
+<!--
 Two typical uses of `__init__` are calling runtime initialization functions of external C libraries
 and initializing global constants that involve pointers returned by external libraries.  For example,
 suppose that we are calling a C library `libfoo` that requires us to call a `foo_init()` initialization
@@ -277,6 +530,13 @@ function at runtime. Suppose that we also want to define a global constant `foo_
 holds the return value of a `void *foo_data()` function defined by `libfoo` -- this constant must
 be initialized at runtime (not at compile time) because the pointer address will change from run
 to run.  You could accomplish this by defining the following `__init__` function in your module:
+-->
+```
+`__init__`の2つの典型的な用途は、C言語の外部Cライブラリの実行時初期化関数を呼び出すことと、外部ライブラリが返すポインタを保持するグローバル定数を初期化することです。
+たとえば、実行時に初期化関数`foo_init()`を呼び出す必要のあるC言語ライブラリ`libfoo`を呼び出すとします。
+また`libfoo`で定義された`void *foo_data()`関数の戻り値を保持するグローバル定数`foo_data_ptr`も定義したいとします。
+すると、ポインタのアドレスは実行ごとに変わるため、この定数は（コンパイル時ではなく）実行時に初期化する必要があります。
+これは、モジュール内に次のような`__init__`関数を定義すれば、実行できます。
 
 ```julia
 const foo_data_ptr = Ref{Ptr{Void}}(0)
@@ -286,6 +546,9 @@ function __init__()
 end
 ```
 
+
+```@raw html
+<!--
 Notice that it is perfectly possible to define a global inside a function like `__init__`; this
 is one of the advantages of using a dynamic language. But by making it a constant at global scope,
 we can ensure that the type is known to the compiler and allow it to generate better optimized
@@ -298,7 +561,23 @@ includes complicated heap-allocated objects like arrays. However, any routine th
 pointer value must be called at runtime for precompilation to work (Ptr objects will turn into
 null pointers unless they are hidden inside an isbits object). This includes the return values
 of the Julia functions `cfunction` and `pointer`.
+-->
+```
+グローバル変数を`__init__`のような関数の内部に定義することは本当に可能であることに注目してください。
+これは動的言語を使用する利点の1つです。
+しかし、これをグローバルスコープにおける定数にすれば、コンパイラが型を認識し、より最適化されたコードが生成することが保証できます。
+明らかに、`foo_data_ptr`に依存するモジュール内のその他のグローバルも`__init__`の中で初期化する必要があります。
 
+`ccall`を使わずに生成される、ほとんどのJuliaオブジェクトを含む定数は、`__init__`に配置する必要はありません。
+その定義は、プリコンパイルして、キャッシュされたモジュールイメージからロードできます。
+これには、配列のようなヒープに割り当てられた複雑なオブジェクトも該当します。
+しかし、生のポインタ値を返すルーチンは、プリコンパイルがうまく動作するように実行時に呼び出す必要があります（Ptrオブジェクトはisbitsオブジェクト内に隠されていない限り、NULLポインタになります）。
+これには、Juliaの関数`cfunction`や`pointer`の戻り値が該当します。
+
+
+
+```@raw html
+<!--
 Dictionary and set types, or in general anything that depends on the output of a `hash(key)` method,
 are a trickier case.  In the common case where the keys are numbers, strings, symbols, ranges,
 `Expr`, or compositions of these types (via arrays, tuples, sets, pairs, etc.) they are safe to
@@ -309,16 +588,45 @@ If you have one of these key types, or if you aren't sure, to be safe you can in
 dictionary from within your `__init__` function. Alternatively, you can use the `ObjectIdDict`
 dictionary type, which is specially handled by precompilation so that it is safe to initialize
 at compile-time.
+-->
+```
+辞書や集合の型、また一般に`hash(key)`メソッドの出力に依存するものはすべて、取り扱いが厄介です。
+keyが数字、文字列、記号、範囲、`Expr`、またこれらの型の複合（配列、タプル、セット、ペアなど）である一般的な事例では、プリコンパイルしても安全です。
+ただし、他のkeyの型、例えば`Function`や`DataType`や汎化的なユーザー定義型など、`hash`メソッドを直接定義していない型のの場合、二次的な`hash`メソッドは（`object_id`を介する）オブジェクトのメモリアドレスに依存するので、実行ごとに変更される可能性があります。
+keyの型が以上のいずれかの場合や、わからない場合は、安全のために`__init__`関数の中からこの辞書を初期化することができます。
+また、`ObjectIdDict`という辞書型をかわりに利用することもできます。
+これは、コンパイル時に安全に初期化できるように、プリコンパイルで特殊な処理が行われる辞書型です。
 
+
+
+```@raw html
+<!--
 When using precompilation, it is important to keep a clear sense of the distinction between the
 compilation phase and the execution phase. In this mode, it will often be much more clearly apparent
 that Julia is a compiler which allows execution of arbitrary Julia code, not a standalone interpreter
 that also generates compiled code.
 
+-->
+```
+
+プリコンパイルを使用する場合は、コンパイル・フェーズと実行フェーズの区別を明確に意識し続けることが重要です。
+このプリコンパイルというモードでは、よりよく明白になることがあります。
+Juliaは任意のJuliaで書かれたコードを実行できるコンパイラであり、コンパイルされたコードを生成するスタンドアロンインタプリタではないということです。
+
+```@raw html
+<!--
+
 Other known potential failure scenarios include:
 
 1. Global counters (for example, for attempting to uniquely identify objects) Consider the following
    code snippet:
+-->
+```
+その他の失敗しがちだと知られているシナリオには以下のようなものがあります。
+
+    1.グローバルカウンタ（たとえば、オブジェクトを一意に識別しようとする場合）で
+    次のコードのスニペットを考えてみましょう。
+
 
    ```julia
    mutable struct UniquedById
@@ -329,6 +637,9 @@ Other known potential failure scenarios include:
    end
    ```
 
+
+```@raw html
+<!--
    while the intent of this code was to give every instance a unique id, the counter value is recorded
    at the end of compilation. All subsequent usages of this incrementally compiled module will start
    from that same counter value.
@@ -338,6 +649,18 @@ Other known potential failure scenarios include:
 
    One alternative is to store both [`current_module()`](@ref) and the current `counter` value, however,
    it may be better to redesign the code to not depend on this global state.
+-->
+```
+このコードはすべてのインスタンスに一意的なIDを与えることを意図していますが、カウンタ値はコンパイルの最後に記録されます。モジュールの逐次コンパイルされた後に使うと、いつも同じカウンタ値から始まります。
+
+`object_id`（メモリポインタをハッシュすることによって動作する）にも同様の問題があるので注意してください（下記の`Dict`の用法を参照)。
+
+代替案として [`current_module()`](@ref)と現在の`counter`値の両方を保存する方法もありますが、グローバル状態に依存しないようにコードを再設計するほうがよい場合があります。
+
+
+
+```@raw html
+<!--
 2. Associative collections (such as `Dict` and `Set`) need to be re-hashed in `__init__`. (In the
    future, a mechanism may be provided to register an initializer function.)
 3. Depending on compile-time side-effects persisting through load-time. Example include: modifying
@@ -345,7 +668,16 @@ Other known potential failure scenarios include:
    storing pointers to other system resources (including memory);
 4. Creating accidental "copies" of global state from another module, by referencing it directly instead
    of via its lookup path. For example, (in global scope):
+-->
+```
+2.連想コレクション(`Dict`や`Set`など）は`__init__`内で再ハッシュ化する必要があります。（将来的に、初期化関数を登録するためのメカニズムが提供されるかもしれません。）
 
+3.コンパイル時に副作用があるとその影響はロード後も残ったままです。
+例をあげると、他のJuliaモジュールの配列や他の変数を変更する、 
+ファイルやデバイスを開くためのハンドルを保持する、
+他のシステムのリソース（メモリを含む）へのポインタを格納するなどです。
+
+4.他のモジュールに対して、ルックアップパス経由ではなく直接参照すると、グローバルな状態の偶発的な「コピー」が作成されてしまう。（グローバルスコープ内での）例を挙げると、
    ```julia
    #mystdout = Base.STDOUT #= will not work correctly, since this will copy Base.STDOUT into this module =#
    # instead use accessor functions:
@@ -354,6 +686,9 @@ Other known potential failure scenarios include:
    __init__() = global mystdout = Base.STDOUT #= also works =#
    ```
 
+
+```@raw html
+<!--
 Several additional restrictions are placed on the operations that can be done while precompiling
 code to help the user avoid other wrong-behavior situations:
 
@@ -362,7 +697,18 @@ code to help the user avoid other wrong-behavior situations:
 2. `global const` statements from local scope after `__init__()` has been started (see issue #12010
    for plans to add an error for this)
 3. Replacing a module (or calling [`workspace()`](@ref)) is a runtime error while doing an incremental precompile.
+-->
+```
+コードをプリコンパイルしている間に実行できる操作は、ユーザーが他の過ちを犯しやすい状況を避けるために、さらなる制限がいくつかあります。
 
+    1. [`eval`](@ref)を呼び出して他のモジュールに副作用を引き起こすこと。
+     インクリメンタル・プリコンパイル・フラグが設定されている場合に警告が出されます。
+    2.`__init__()`の開始後にローカルスコープから`global const`文を書くこと（これにエラーを追加する計画については、問題＃12010を参照してください）
+    3.モジュールを置き換える(または[`workspace()`](@ref) を呼び出す)こと。
+    逐次プリコンパイル中はランタイムエラーが起こります。
+
+```@raw html
+<!--
 A few other points to be aware of:
 
 1. No code reload / cache invalidation is performed after changes are made to the source files themselves,
@@ -380,7 +726,25 @@ A few other points to be aware of:
    as this can confuse the serializer and may not lead to the outcome you desire. It is not necessarily
    an error to do this, but you simply need to be prepared that the system will try to copy some
    of these and to create a single unique instance of others.
+-->
+```
+他の注意すべき点をいくつか挙げます。
 
+    1.ソースファイル自体が変更された後（[`Pkg.update`](@ref)によるものも含めて）、
+    コードのリロードやキャッシュの無効化は実行されず、[`Pkg.rm`](@ref)の後にクリーンアップは行われません。
+    2.再構成された配列にメモリ共有を行っても、プリコンパイルでは無視されます（各ビューは独自のコピーを取得します）
+    3.ファイルシステムがコンパイル時と実行時の間で変更されないことを前提としているものに注意すること（例：[`@__FILE__`](@ref)/`source_path()`や`BinDeps @checked_lib`マクロ。)
+    変更を避けられない場合もありますが、可能な場合に、コンパイル時にリソースをモジュールにコピーしておき、実行時にリソースを見つける必要をなくすのはよい手法です。
+    4.`WeakRef` オブジェクトとファイナライザは現時点では、シリアライザによって正しく処理されません（これは、今後のリリースで修正される予定です）。
+    5.次のような内部的なメタデータ・オブジェクトのインスタンスに対しては、参照を捕捉しないのが最善策です。
+    例えば`Method`、`MethodInstance`、`MethodTable`、`TypeMapLevel`、`TypeMapEntry`やこれらのオブジェクトのフィールドです。
+    捕捉するとシリアライザが混同する可能性がありますし、望むような結果がえられない可能性があります。
+    捕捉することは必ずしも間違いではありませんが、単にコピーを取って一意的な別のインスタンスを作成するようにしておけばすむ話です。
+
+
+
+```@raw html
+<!--
 It is sometimes helpful during module development to turn off incremental precompilation. The
 command line flag `--compilecache={yes|no}` enables you to toggle module precompilation on and
 off. When Julia is started with `--compilecache=no` the serialized modules in the compile cache
@@ -388,3 +752,10 @@ are ignored when loading modules and module dependencies. `Base.compilecache()` 
 manually and it will respect `__precompile__()` directives for the module. The state of this command
 line flag is passed to [`Pkg.build()`](@ref) to disable automatic precompilation triggering when installing,
 updating, and explicitly building packages.
+-->
+```
+逐次プリコンパイルをオフにすると、モジュール開発中に役立つことが時々あります。
+コマンドラインフラグの`--compilecache={yes|no}`を使って、モジュールのプリコンパイルのオンとオフを切り替えることができます。
+`--compilecache=no`でJuliaを起動すると、モジュールやモジュールの依存をロードするときに、コンパイル時に直列化してキャッシュされたモジュールが無視されます。
+`Base.compilecache()`は依然として手動で呼び出すことができますが、モジュールに対する`__precompile__()`ディレクティブを尊重します。
+このコマンドラインフラグの状態は[`Pkg.build()`](@ref)に渡されて、パッケージのインストール・更新・明示的なビルドをトリガーとする、自動プリコンパイルが無効になります。

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1,5 +1,9 @@
-# [Types](@id man-types)
+[](# [Types](@id man-types))
+# [型](@id man-types)
 
+
+```@raw html
+<!--
 Type systems have traditionally fallen into two quite different camps: static type systems, where
 every program expression must have a type computable before the execution of the program, and
 dynamic type systems, where nothing is known about types until run time, when the actual values
@@ -8,19 +12,50 @@ typed languages by letting code be written without the precise types of values b
 compile time. The ability to write code that can operate on different types is called polymorphism.
 All code in classic dynamically typed languages is polymorphic: only by explicitly checking types,
 or when objects fail to support operations at run-time, are the types of any values ever restricted.
+-->
+```
+型システムは伝統的にまったく異なる2つの陣営に分類されてきました。静的型システムと動的型システムです。
+静的型システムでは、すべてのプログラムの式は、実行前に型が算出可能でなくてはなりません。
+動的型システムでは、処理するデータが利用可能になる実行時まで、型についてなにもわかりません。
+静的型システムでもオブジェクト指向ではある程度は柔軟で、コンパイル時に値の正確な型がわからなくても
+プログラムを書くことができます。
+異なる型に対して動作可能なプログラムを記述できる能力を多相性[訳注1]_といいます。
+古典的な動的型付言語はすべて多相的です。
+型に制約が生じるのは、明示的に型検査を行う場合か、オブジェクトが実行時に操作に対応できなくなった場合
+くらいのものでしょう。
 
+```@raw html
+<!--
 Julia's type system is dynamic, but gains some of the advantages of static type systems by making
 it possible to indicate that certain values are of specific types. This can be of great assistance
 in generating efficient code, but even more significantly, it allows method dispatch on the types
 of function arguments to be deeply integrated with the language. Method dispatch is explored in
 detail in [Methods](@ref), but is rooted in the type system presented here.
+-->
+```
+Juliaの型システムは動的ですが、静的型付システムの利点も、ある程度取り入れています。
+ある種の値に対しては、型を判定できるのです。これは、効率的なコードを生成するのに大いに役立っています。
+しかし、さらに重要なのは、関数の引数の型に対するメソッド・ディスパッチが可能になり、この機能がJulia言語に深く統合されていることです。
+メソッド・ディスパッチは[メソッド](@ref)で詳説しますが、根本となるのは、ここに示した型システムなのです。
 
+
+```@raw html
+<!--
 The default behavior in Julia when types are omitted is to allow values to be of any type. Thus,
 one can write many useful Julia programs without ever explicitly using types. When additional
 expressiveness is needed, however, it is easy to gradually introduce explicit type annotations
 into previously "untyped" code. Doing so will typically increase both the performance and robustness
 of these systems, and perhaps somewhat counterintuitively, often significantly simplify them.
+-->
+```
+型を省略した時は、値がどんな型であっても許されるのが、Juliaのデフォルトの動作です。
+つまり、型をわざわざ指定しなくても、Juliaなら有用なプログラムを沢山かけるのです。
+しかし必要に応じて、もともと*型指定のなかった**コードに、少しづつ型注釈を書き加えていくのも簡単なのです。
+型注釈を加えると、通常は、システムのパフォーマンスと堅牢性が向上します。
+そして、おそらくなにか直観に反する気がするでしょうが、非常に単純化されることもよく起こります。
 
+```@raw html
+<!--
 Describing Julia in the lingo of [type systems](https://en.wikipedia.org/wiki/Type_system), it
 is: dynamic, nominative and parametric. Generic types can be parameterized, and the hierarchical
 relationships between types are [explicitly declared](https://en.wikipedia.org/wiki/Nominal_type_system),
@@ -32,7 +67,19 @@ few drawbacks. It turns out that being able to inherit behavior is much more imp
 able to inherit structure, and inheriting both causes significant difficulties in traditional
 object-oriented languages. Other high-level aspects of Julia's type system that should be mentioned
 up front are:
+-->
+```
+Juliaについて[型システム](https://en.wikipedia.org/wiki/Type_system) の術語を使って記述すると,動的、公称的、パラメータ的です。
+汎化型によってパラメータ化が可能となり、型の階層関係は、[明示的に宣言](https://en.wikipedia.org/wiki/Nominal_type_system)するのであって、 
+[互換構造から推論](https://en.wikipedia.org/wiki/Structural_type_system)されるわけではありません。
+Juliaの型システムに独自の特徴の一つは、具象型は互いのサブタイプとはならない点です。
+すべての具象型は拡張できず、抽象型のスーパータイプを持てるのみです。　
+はじめは、この制約が不当に厳しく思えるかも知れませんが、多くの利点があり、欠点はほとんどないのです。
+振る舞いを継承できるほうが、構造を継承できるよりも重要であり、共に継承しようとすると、従来のオブジェクト指向言語では、深刻な困難が生じることがわかっています。
+他に、先に言及すべきJuliaの型システムの高水準な特徴をあげると、
 
+```@raw html
+<!--
   * There is no division between object and non-object values: all values in Julia are true objects
     having a type that belongs to a single, fully connected type graph, all nodes of which are equally
     first-class as types.
@@ -45,27 +92,63 @@ up front are:
     like numbers and bools that are stored like C types or structs with no pointers to other objects),
     and also by tuples thereof. Type parameters may be omitted when they do not need to be referenced
     or restricted.
+-->
+```
+   * オブジェクトか非オブジェクトかという値の区別がありません。Juliaでは、すべての値は型を持つ真のオブジェクトです。その型は、すべてのノードが型として等しく第一級である、完全に連結した単一の型のグラフに属しています。
+  * 「コンパイル時の型」という考え方は全く無意味です。値のとる型はただ一つであり、実行時に実際にとるものだけです。これはオブジェクト指向言語では「実行時型」と呼ばれ、オブジェクト指向言語において多相型の静的コンパイルを行うときは、この型の違いは重要になります。
+  * 変数ではなく、値だけが型を持ちます。変数は値に束縛された単なる名前です。 
+  * 抽象型と具象型は両方とも、他の型によるパラメータ化可能です。型以外にも、シンボル、値でその型が[`isbits()`](@ref) で真となるもの（本質的には数やブール値のような、他のオブジェクトへのポインタを持たないC言語の型や構造体などに格納されるもの）、及びこれらのタプルなどによってパラメータ化可能です。参照や制限をする必要がない場合は、型パラメータは省略しても構いません。
 
+
+```@raw html
+<!--
 Julia's type system is designed to be powerful and expressive, yet clear, intuitive and unobtrusive.
 Many Julia programmers may never feel the need to write code that explicitly uses types. Some
 kinds of programming, however, become clearer, simpler, faster and more robust with declared types.
+-->
+```
+Juliaの型システムは、強力で表現力豊かだけれども、わかりやすく直観的で目障りにならないように設計されています。
+Juliaのプログラマは、型を明示してコードを書く必要性をまったく感じない人が多いかもしれません。しかし、ある種のプログラムでは、型を宣言すると、より明快で、単純で、速く、堅牢になります。
 
-## Type Declarations
+[](## Type Declarations)
+## 型宣言
 
+
+```@raw html
+<!--
 The `::` operator can be used to attach type annotations to expressions and variables in programs.
 There are two primary reasons to do this:
 
 1. As an assertion to help confirm that your program works the way you expect,
 2. To provide extra type information to the compiler, which can then improve performance in some
    cases
+-->
+```
+`::`演算子は、プログラム内の式や変数に型注釈を付ける用途に使用できます。
+型注釈をつける理由は、主に2つあります。
 
+1.    型注釈を表明として扱い、プログラムに想定される動作の確認に役立てる。
+2.    コンパイラが追加的な型情報を利用できるようにして、状況によってはパフォーマンスを向上できるようにする。
+
+
+
+```@raw html
+<!--
 When appended to an expression computing a value, the `::` operator is read as "is an instance
 of". It can be used anywhere to assert that the value of the expression on the left is an instance
 of the type on the right. When the type on the right is concrete, the value on the left must have
 that type as its implementation -- recall that all concrete types are final, so no implementation
 is a subtype of any other. When the type is abstract, it suffices for the value to be implemented
-by a concrete type that is a subtype of the abstract type. If the type assertion is not true,
+by a concrete type that is a subtype of the abstract type.  the type assertion is not true,
 an exception is thrown, otherwise, the left-hand value is returned:
+-->
+```
+計算式に追加した`::`演算子は、 "is an instance of(～のインスタンスである)"と読み下すことができます。
+`::`演算子はどこでも使用できて、`::`の左側の式の値は、右側の型のインスタンスであることを表明します。
+`::`の右側が具象型の場合、左辺の値はその型の実装でなければなりません。
+すべて具象型は拡張できず、その実装は他の具象型の実装とはならないことを思い出してください。
+抽象型の場合は、その抽象型のサブタイプの具象型によって値が実装されていれば十分です。
+型表明が真でない場合は例外が投げられますが、そうでなければ左側の値が返されます。
 
 ```jldoctest
 julia> (1+2)::AbstractFloat
@@ -75,12 +158,22 @@ julia> (1+2)::Int
 3
 ```
 
+
+```@raw html
+<!--
 This allows a type assertion to be attached to any expression in-place.
 
 When appended to a variable on the left-hand side of an assignment, or as part of a `local` declaration,
 the `::` operator means something a bit different: it declares the variable to always have the
 specified type, like a type declaration in a statically-typed language such as C. Every value
 assigned to the variable will be converted to the declared type using [`convert()`](@ref):
+-->
+```
+このようにすると、プログラム内の任意の式に型表明を差し込むことができます。
+
+代入文の左側の変数や、`local`宣言の一部に追加されると、::演算子の意味が少し変わります。
+つまり、C言語のような静的型付き言語の型宣言のように、常に変数は指定した型であるという宣言になります。
+変数に代入される値はすべて、宣言された型に [`convert()`](@ref) を使って変換されます。
 
 ```jldoctest
 julia> function foo()
@@ -96,21 +189,43 @@ julia> typeof(ans)
 Int8
 ```
 
+
+```@raw html
+<!--
 This feature is useful for avoiding performance "gotchas" that could occur if one of the assignments
 to a variable changed its type unexpectedly.
 
 This "declaration" behavior only occurs in specific contexts:
+-->
+```
+この機能は、変数に代入を行って、想定外の型に変更された時におこりうる、パフォーマンスの「落とし穴」を避けるために役立ちます。
+
+この「宣言」の動作は、特定のコンテキストでのみ発生します。
+
 
 ```julia
 local x::Int8  # in a local declaration
 x::Int8 = 10   # as the left-hand side of an assignment
 ```
 
+
+```@raw html
+<!--
 and applies to the whole current scope, even before the declaration. Currently, type declarations
 cannot be used in global scope, e.g. in the REPL, since Julia does not yet have constant-type
 globals.
 
 Declarations can also be attached to function definitions:
+-->
+```
+
+宣言の前であっても、現在のスコープ全体に適用されます。
+型宣言はREPLなどのグローバルスコープでは使用できません。
+というのも、現時点では、Juliaには
+まだ定数型のグローバル変数がないからです。
+
+また宣言を関数の定義に差し込むこともできます。
+
 
 ```julia
 function sinc(x)::Float64
@@ -121,17 +236,36 @@ function sinc(x)::Float64
 end
 ```
 
+
+```@raw html
+<!--
 Returning from this function behaves just like an assignment to a variable with a declared type:
 the value is always converted to `Float64`.
+-->
+```
 
-## Abstract Types
+この関数の戻り値は、型宣言をした変数への代入と同じように処理されます。値は常に`Float64`に変換されます。
 
+[](## Abstract Types)
+## 抽象型
+
+
+```@raw html
+<!--
 Abstract types cannot be instantiated, and serve only as nodes in the type graph, thereby describing
 sets of related concrete types: those concrete types which are their descendants. We begin with
 abstract types even though they have no instantiation because they are the backbone of the type
 system: they form the conceptual hierarchy which makes Julia's type system more than just a collection
 of object implementations.
+-->
+```
+抽象型はインスタンス化ができなくて、型のグラフの中ではノードになるだけですが、だからこそ
+関連する具象型の集合を記述できるといえます。抽象型に対して子孫となる具象型を集合と考えるのです。
+型の説明は抽象型から始めましょう。インスタンス化はできないですが、型システムのバックボーンだからです。
+抽象型は概念的な階層を形成して、Juliaの型システムを、単なるオブジェクトの実装の寄せ集め以上のものにしています。
 
+```@raw html
+<!--
 Recall that in [整数と浮動小数点数](@ref), we introduced a variety of concrete
 types of numeric values: [`Int8`](@ref), [`UInt8`](@ref), [`Int16`](@ref), [`UInt16`](@ref),
 [`Int32`](@ref), [`UInt32`](@ref), [`Int64`](@ref), [`UInt64`](@ref), [`Int128`](@ref),
@@ -146,19 +280,51 @@ denominator algorithm works for all kinds of integers, but will not work for flo
 numbers. Abstract types allow the construction of a hierarchy of types, providing a context
 into which concrete types can fit. This allows you, for example, to easily program to any type
 that is an integer, without restricting an algorithm to a specific type of integer.
+-->
+```
 
+[整数と浮動小数点数](@ref) で導入した、さまざまな数値の具象型を思い出してください。
+[`Int8`](@ref)、 [`UInt8`](@ref)、 [`Int16`](@ref)、 [`UInt16`](@ref)、 [`Int32`](@ref)、 [`UInt32`](@ref)、 [`Int64`](@ref)、 [`UInt64`](@ref)、 [`Int128`](@ref)、
+[`UInt128`](@ref)、 [`Float16`](@ref)、 [`Float32`](@ref)、 [`Float64`](@ref) です。
+Int8、Int16、Int32、Int64、Int128 は表現のサイズは異なりますが、すべて符号付き整数型という点で共通しています。
+同様にUInt8、UInt16、UInt32、 UInt64、UInt128はすべて、符号なし整数型であり、
+一方、Float16、Float32、Float64は浮動小数点型で、整数型とは別物です。
+あるコードが意図せず動作可能である、ということはよくあることで、たとえば、関数の引数を整数型のなにかに指定していても、じつのところ、特定の整数の**種類**に依存しない場合などです。
+たとえば、最大公約数を求めるアルゴリズムはすべての種類の整数で動作しますが、浮動小数点数では動作しないでしょう。
+抽象型によって、型の階層を形成して、適合する具象型のコンテキストと考えることができます。
+こうすると、例えば、あるアルゴリズムを整数の特定の型に制限することなく、任意の型の整数に対して簡単にプログラムすることができます。
+
+
+
+```@raw html
+<!--
 Abstract types are declared using the `abstract type` keyword. The general syntaxes for declaring an
 abstract type are:
+-->
+```
+抽象型は`abstract type`キーワードを使用して宣言されます。抽象型を宣言する一般的な構文は次のとおりです。
+
 
 ```
 abstract type «name» end
 abstract type «name» <: «supertype» end
 ```
 
+
+```@raw html
+<!--
 The `abstract type` keyword introduces a new abstract type, whose name is given by `«name»`. This
 name can be optionally followed by `<:` and an already-existing type, indicating that the newly
 declared abstract type is a subtype of this "parent" type.
+-->
+```
+`abstract type`キーワードは、その名前を`«name»`とする、新たな抽象型を導入します。
+必要に応じて、この名前の後に`<:`と既存の型を続けた場合、新たに宣言された抽象型がこの既存の型を「親」とするサブタイプであることを意味します。
 
+
+
+```@raw html
+<!--
 When no supertype is given, the default supertype is `Any` -- a predefined abstract type that
 all objects are instances of and all types are subtypes of. In type theory, `Any` is commonly
 called "top" because it is at the apex of the type graph. Julia also has a predefined abstract
@@ -166,7 +332,15 @@ called "top" because it is at the apex of the type graph. Julia also has a prede
 opposite of `Any`: no object is an instance of `Union{}` and all types are supertypes of `Union{}`.
 
 Let's consider some of the abstract types that make up Julia's numerical hierarchy:
+-->
+```
+スーパータイプの指定がない場合、デフォルトのスーパータイプは`Any`です。
+`Any`は事前に定義された抽象型で、すべてのオブジェクトは`Any`のインスタンスであり、すべての型が`Any`のサブタイプです。
+型理論で`Any`は、型のグラフの頂点にあるため、通常「トップ」と呼ばれます。
+またJuliaには、事前に定義された抽象型の「ボトム」があり、型のグラフの最下位にあって、`Union{}`と書きます。
+これは`Any`のちょうど逆で、すべてのオブジェクトは`Union{}`のインスタンスではなく、すべての型が`Union{}`のスーパータイプです。
 
+Juliaの数の階層を構成する抽象型をいくつか考えてみましょう。
 ```julia
 abstract type Number end
 abstract type Real     <: Number end
@@ -176,6 +350,9 @@ abstract type Signed   <: Integer end
 abstract type Unsigned <: Integer end
 ```
 
+
+```@raw html
+<!--
 The [`Number`](@ref) type is a direct child type of `Any`, and [`Real`](@ref) is its child.
 In turn, `Real` has two children (it has more, but only two are shown here; we'll get to
 the others later): [`Integer`](@ref) and [`AbstractFloat`](@ref), separating the world into
@@ -184,11 +361,26 @@ numbers include, of course, floating-point types, but also include other types, 
 rationals. Hence, `AbstractFloat` is a proper subtype of `Real`, including only
 floating-point representations of real numbers. Integers are further subdivided into
 [`Signed`](@ref) and [`Unsigned`](@ref) varieties.
+-->
+```
+[`Number`](@ref) 型は`Any`の直下の子の型であり、[`Real`](@ref) は[`Number`](@ref) の子です。`Real`には子が２つあります（もっとありますが、ここでとりあげるのは2つだけです。後で他のものにも触れます）。
+[`Integer`](@ref) と [`AbstractFloat`](@ref) は数の世界を整数の表現と実数の表現に分けます。
+実数の表現には、もちろん浮動小数点型が該当しますが、有理数などの他の型も該当します。
+したがって、 `AbstractFloat` は`Real`の真のサブタイプで、実数のうち浮動小数点数の表現のみを含みます。
+整数はさらに[`Signed`](@ref) と [`Unsigned`](@ref) に細分されます。
 
+
+
+```@raw html
+<!--
 The `<:` operator in general means "is a subtype of", and, used in declarations like this, declares
 the right-hand type to be an immediate supertype of the newly declared type. It can also be used
 in expressions as a subtype operator which returns `true` when its left operand is a subtype of
 its right operand:
+-->
+```
+通常、`<:`演算子は、「is a subtype of（～のサブタイプである）」を意味し、宣言に使う場合は、右側の型が新しく宣言する型の直のスーパータイプであるという宣言を意味します。
+`<:`演算子はサブタイプ演算子として使うこともできて、左側の被演算子が右側の被演算子のサブタイプであるときに真を返します。
 
 ```jldoctest
 julia> Integer <: Number
@@ -198,8 +390,16 @@ julia> Integer <: AbstractFloat
 false
 ```
 
+
+```@raw html
+<!--
 An important use of abstract types is to provide default implementations for concrete types. To
 give a simple example, consider:
+-->
+```
+
+抽象型の重要な用途は、具象型のデフォルトの実装を提供することです。簡単な例を挙げてみましょう。
+
 
 ```julia
 function myplus(x,y)
@@ -207,14 +407,28 @@ function myplus(x,y)
 end
 ```
 
+
+```@raw html
+<!--
 The first thing to note is that the above argument declarations are equivalent to `x::Any` and
 `y::Any`. When this function is invoked, say as `myplus(2,5)`, the dispatcher chooses the most
 specific method named `myplus` that matches the given arguments. (See [Methods](@ref) for more
 information on multiple dispatch.)
+-->
+```
 
+まず注意すべきことは、上記の引数の宣言は `x::Any`かつ`y::Any`と同等であることです。
+この関数がたとえば`myplus(2,5)`のように呼び出されると、ディスパッチャは`myplus`と名がつくメソッドで引数の合うものの中から最も特化したメソッドを選択します。（多重ディスパッチの詳細については、[メソッド](@ref)を参照してください。）
+
+```@raw html
+<!--
 Assuming no method more specific than the above is found, Julia next internally defines and compiles
 a method called `myplus` specifically for two `Int` arguments based on the generic function given
 above, i.e., it implicitly defines and compiles:
+-->
+```
+上記のメソッドより適切なものが見つからない場合は、引き続きJuliaは内部的に`myplus`という名のメソッドを、上記の汎化関数に、2つの引数を`Int`に特化した上で、定義とコンパイルを行います。つまり、暗黙的に定義とコンパイルをおこないます。
+
 
 ```julia
 function myplus(x::Int,y::Int)
@@ -222,23 +436,53 @@ function myplus(x::Int,y::Int)
 end
 ```
 
+
+```@raw html
+<!--
 and finally, it invokes this specific method.
 
 Thus, abstract types allow programmers to write generic functions that can later be used as the
 default method by many combinations of concrete types. Thanks to multiple dispatch, the programmer
 has full control over whether the default or more specific method is used.
+-->
+```
+最後に、この特化メソッドを呼び出します。
 
+このように、抽象型を使用すると、プログラマは、あとあと、具象型の組み合わせの多くに対してデフォルトのメソッドとして使用できる汎化関数を、記述できます。
+多重ディスパッチのおかげで、プログラマは、デフォルトのメソッドと、より特化したメソッドのどちらを使用するかを完全に制御できます。
+
+
+
+```@raw html
+<!--
 An important point to note is that there is no loss in performance if the programmer relies on
 a function whose arguments are abstract types, because it is recompiled for each tuple of argument
 concrete types with which it is invoked. (There may be a performance issue, however, in the case
 of function arguments that are containers of abstract types; see [Performance Tips](@ref man-performance-tips).)
+-->
+```
+注目すべき重要な点は、引数が抽象型である関数を使っても、パフォーマンスが落ちないことです。
+というのも関数は、呼び出される引数の具象型の組が異なるごとに、再コンパイルされるからです。
+（ただし、関数の引数が抽象型のコンテナである場合は、パフォーマンス上、問題になる可能性があります（[パフォーマンスのヒント]（@ ref man-performance-tips）を参照してください）。
 
-## Primitive Types
+[](## Primitive Types)
+## 原始型
 
+
+```@raw html
+<!--
 A primitive type is a concrete type whose data consists of plain old bits. Classic examples of primitive
 types are integers and floating-point values. Unlike most languages, Julia lets you declare your
 own primitive types, rather than providing only a fixed set of built-in ones. In fact, the standard
 primitive types are all defined in the language itself:
+-->
+```
+
+原始型は、データが普通のビットで構成される具象型です。
+原始型の定番の例は、整数と浮動小数点数です。
+ほとんどの言語とは異なり、Juliaでは標準装備の固定した原始型が利用可能なだけではなく、独自の原始型を宣言することができます。
+実際、標準装備の原始型はすべてJulia自体で定義されています。
+
 
 ```julia
 primitive type Float16 <: AbstractFloat 16 end
@@ -260,13 +504,23 @@ primitive type Int128  <: Signed   128 end
 primitive type UInt128 <: Unsigned 128 end
 ```
 
+
+```@raw html
+<!--
 The general syntaxes for declaring a primitive type are:
+-->
+```
+原始型を宣言するための一般的な構文は次のとおりです。
+
 
 ```
 primitive type «name» «bits» end
 primitive type «name» <: «supertype» «bits» end
 ```
 
+
+```@raw html
+<!--
 The number of bits indicates how much storage the type requires and the name gives the new type
 a name. A primitive type can optionally be declared to be a subtype of some supertype. If a supertype
 is omitted, then the type defaults to having `Any` as its immediate supertype. The declaration
@@ -274,7 +528,19 @@ of [`Bool`](@ref) above therefore means that a boolean value takes eight bits to
 [`Integer`](@ref) as its immediate supertype. Currently, only sizes that are multiples of
 8 bits are supported. Therefore, boolean values, although they really need just a single bit,
 cannot be declared to be any smaller than eight bits.
+-->
+```
+ビット数は、その型が格納に何ビット必要とするかを示し、新しい型の名前に使われます。
+原始型は、必要に応じてどのスーパータイプのサブタイプなのかを宣言することができます。
+スーパータイプを省略すると、デフォルトでは、`Any`がその型の直接のスーパータイプになります。
+したがって、上記の[`Bool`](@ref) 宣言は、ブール値の格納に8ビットを要し、[`Integer`](@ref) が直接のスーパータイプであることを意味しています 。
+現在は、8ビットの倍数であるサイズのみが利用可能です。
+したがって、ブール値に本当に必要なのは1ビットだけですが、8ビットより小さい宣言にはできません。
 
+
+
+```@raw html
+<!--
 The types [`Bool`](@ref), [`Int8`](@ref) and [`UInt8`](@ref) all have identical representations:
 they are eight-bit chunks of memory. Since Julia's type system is nominative, however, they
 are not interchangeable despite having identical structure. A fundamental difference between
@@ -285,15 +551,35 @@ behavior -- the way functions are defined to act when given objects of these typ
 arguments. This is why a nominative type system is necessary: if structure determined type,
 which in turn dictates behavior, then it would be impossible to make [`Bool`](@ref) behave
 any differently than [`Int8`](@ref) or [`UInt8`](@ref).
+-->
+```
+ [`Bool`](@ref)、 [`Int8`](@ref)、 [`UInt8`](@ref) の型はすべて同一の表現です。これらは8ビットのメモリの塊です。
+ しかし、Juliaの型システムは公称的であるため、同一の構造であっても互換性はありません。
+ これらの基本的な違いは、スーパータイプが異なることです。
+  [`Bool`](@ref) の直接のスーパータイプは [`Integer`](@ref) 、[`Int8`](@ref) は[`Signed`](@ref)、 [`UInt8`](@ref)は [`Unsigned`](@ref)です。
+ [`Bool`](@ref)、 [`Int8`](@ref)、 [`UInt8`](@ref) のその他の違いはすべて挙動にかかわるものです。
+ つまり、それぞれの型のオブジェクトを引数にとる時に、関数の動作がどう定義されているかの違いです。
+ これが公称的な型システムが必要な理由です。もしも構造によって型が決定するならば、型の構造から挙動がそのまま決まってしまうので、[`Bool`](@ref) が
+ [`Int8`](@ref) や [`UInt8`](@ref) と異なる挙動をとることは不可能になるでしょう。
 
-## Composite Types
+[](## Composite Types)
+## 複合型
 
+```@raw html
+<!--
 [Composite types](https://en.wikipedia.org/wiki/Composite_data_type) are called records, structs,
 or objects in various languages. A composite type is a collection of named fields,
 an instance of which can be treated as a single value. In many languages, composite types are
 the only kind of user-definable type, and they are by far the most commonly used user-defined
 type in Julia as well.
+-->
+```
+[複合型](https://en.wikipedia.org/wiki/Composite_data_type) は、レコード、構造体、オブジェクトなど、言語によって様々に呼ばれます。
+複合型は、名前付きフィールドの集合体であり、そのインスタンスは単一の値として扱うことができます。
+多くの言語では、複合型のみがユーザーの定義義可能な型であり、Juliaでも最も一般的に使われるユーザ定義型です。
 
+```@raw html
+<!--
 In mainstream object oriented languages, such as C++, Java, Python and Ruby, composite types also
 have named functions associated with them, and the combination is called an "object". In purer
 object-oriented languages, such as Ruby or Smalltalk, all values are objects whether they are
@@ -307,9 +593,27 @@ for more information on methods and dispatch). Thus, it would be inappropriate f
 "belong" to only their first argument. Organizing methods into function objects rather than having
 named bags of methods "inside" each object ends up being a highly beneficial aspect of the language
 design.
+-->
+```
+C++、Java、Python、Rubyなどの主流のオブジェクト指向言語では、複合型に名前付き関数が関連づけられて、その組み合わせは「オブジェクト」と呼ばれます。
+RubyやSmalltalkのような、より純粋なオブジェクト指向言語では、すべての値は複合型であろうとなかろうとオブジェクトです。
+少し不純なオブジェクト指向言語（C ++やJavaなど）では、整数や浮動小数点数などの一部の値はオブジェクトではないですが、
+ユーザーの定義する複合型のインスタンスは、関連づけられたメソッドを持つ真のオブジェクトです。
+Juliaでは、すべての値がオブジェクトですが、関数は操作対象のオブジェクトに関連づけられていません。
 
+この仕様が必要なのは、Juliaでは、関数に対して使われるメソッドは、多重ディスパッチによって選択されるからです。
+つまり、メソッドを選択するときには、**すべての**関数の引数の型が考慮され、最初の引数のみではないからです（メソッドとディスパッチの詳細については、[メソッド](@ref)を参照してください）。
+したがって、関数が最初の引数だけに「属する」のは不適切です。
+各オブジェクトの "内側"にたくさんの名前付きのメソッドをいれるより、メソッド群を編成して関数オブジェクトにする方が、言語設計上、非常に有益です。
+
+```@raw html
+<!--
 Composite types are introduced with the `struct` keyword followed by a block of field names, optionally
 annotated with types using the `::` operator:
+-->
+```
+複合型を定義するには、`struct`キーワードのあとにフィールド名のブロックを置き、必要に応じて`::`演算子を使って型注釈を加えます。
+
 
 ```jldoctest footype
 julia> struct Foo
@@ -319,10 +623,19 @@ julia> struct Foo
        end
 ```
 
+
+```@raw html
+<!--
 Fields with no type annotation default to `Any`, and can accordingly hold any type of value.
 
 New objects of type `Foo` are created by applying the `Foo` type object like a function
 to values for its fields:
+-->
+```
+型注釈のないフィールドは、デフォルトでは`Any`型なので、どんな型の値でも保持することができます。
+
+型`Foo`の新しいオブジェクトは、型オブジェクト`Foo`を、そのフィールド値に対して、関数のように適用して作成します。
+
 
 ```jldoctest footype
 julia> foo = Foo("Hello, world.", 23, 1.5)
@@ -332,6 +645,9 @@ julia> typeof(foo)
 Foo
 ```
 
+
+```@raw html
+<!--
 When a type is applied like a function it is called a *constructor*. Two constructors are generated
 automatically (these are called *default constructors*). One accepts any arguments and calls
 [`convert()`](@ref) to convert them to the types of the fields, and the other accepts arguments
@@ -340,6 +656,15 @@ it easier to add new definitions without inadvertently replacing a default const
 
 Since the `bar` field is unconstrained in type, any value will do. However, the value for `baz`
 must be convertible to `Int`:
+-->
+```
+型は関数のように適用するとき、**コンストラクタ**と呼ばれます。
+2つのコンストラクタが自動的に生成されます（これらは**デフォルトコンストラクタ**と呼ばれます）。
+1つはどんな引数でも受け入れて、[`convert()`](@ref) を呼び出してフィールドの型に変換します。
+もう1つはフィールドの型と完全に一致する引数を受け取ります。
+2つのコンストラクタが生成されるのは、新しい定義を追加を簡単に、不注意でデフォルトのコンストラクタを置き換えることなく、できるようにするためです。
+
+`bar`フィールドには型の制約はないので、値は何でも構いません。ただし、`baz`の値は`Int`に変換できる必要があります。
 
 ```jldoctest footype
 julia> Foo((), 23.5, 1)
@@ -349,7 +674,14 @@ Stacktrace:
  [2] Foo(::Tuple{}, ::Float64, ::Int64) at ./none:2
 ```
 
+
+```@raw html
+<!--
 You may find a list of field names using the `fieldnames` function.
+-->
+```
+`fieldnames`関数を使用して、フィールド名を列挙することができます。
+
 
 ```jldoctest footype
 julia> fieldnames(foo)
@@ -359,7 +691,14 @@ julia> fieldnames(foo)
  :qux
 ```
 
+
+```@raw html
+<!--
 You can access the field values of a composite object using the traditional `foo.bar` notation:
+-->
+```
+伝統的な`foo.bar`表記法を使用して、複合型のオブジェクトのフィールド値にアクセスできます。
+
 
 ```jldoctest footype
 julia> foo.bar
@@ -372,6 +711,9 @@ julia> foo.qux
 1.5
 ```
 
+
+```@raw html
+<!--
 Composite objects declared with `struct` are *immutable*; they cannot be modified
 after construction. This may seem odd at first, but it has several advantages:
 
@@ -379,7 +721,21 @@ after construction. This may seem odd at first, but it has several advantages:
     compiler is able to avoid allocating immutable objects entirely.
   * It is not possible to violate the invariants provided by the type's constructors.
   * Code using immutable objects can be easier to reason about.
+-->
+```
+`struct`で宣言された複合型オブジェクトは**不変**です。生成後に変更することはできません。
+これは最初は奇妙に思えるかもしれませんが、いくつかの利点があります：
 
+* より効率的にできます。構造体には効率的に配列にパックできるものもあり、場合によっては、コンパイラは、不変オブジェクトへのメモリの割り当てを完全に避けることができます。
+* 型コンストラクタで規定される不変性を破ることはできません。
+* 不変オブジェクトを使ったコードは、理解しやすくなります。
+
+
+
+
+
+```@raw html
+<!--
 An immutable object might contain mutable objects, such as arrays, as fields. Those contained
 objects will remain mutable; only the fields of the immutable object itself cannot be changed
 to point to different objects.
@@ -388,6 +744,15 @@ Where required, mutable composite objects can be declared with the keyword `muta
 discussed in the next section.
 
 Composite types with no fields are singletons; there can be only one instance of such types:
+-->
+```
+不変オブジェクトには、配列などの可変なオブジェクトがフィールドとして含まれることがあります。
+含まれているオブジェクトは可変のままです。
+不変オブジェクトのフィールド自体が、別のオブジェクトを指すように変更できなくなるだけです。
+
+必要に応じて、可変な複合オブジェクトをキーワード`mutable struct`で宣言することができます（次のセクションで検討します）。
+
+フィールドのない複合型はシングルトンです。そのような型のインスタンスは1つしか作れません。
 
 ```jldoctest
 julia> struct NoFields
@@ -397,24 +762,41 @@ julia> NoFields() === NoFields()
 true
 ```
 
+
+```@raw html
+<!--
 The `===` function confirms that the "two" constructed instances of `NoFields` are actually one
 and the same. Singleton types are described in further detail [below](@ref man-singleton-types).
 
 There is much more to say about how instances of composite types are created, but that discussion
 depends on both [Parametric Types](@ref) and on [Methods](@ref), and is sufficiently important
 to be addressed in its own section: [Constructors](@ref man-constructors).
+-->
+```
+`===`関数によって、`NoFields`の「2つの」生成されたインスタンスが、実際には同一であることを確認できます。
+シングルトン型については、[below](@ref man-singleton-types) で詳しく説明します。
 
-## Mutable Composite Types
+複合型のインスタンスがどのように作成されるかについては、もっと多くの言うべきことがありますが、その議論は[パラメトリック型](@ref) と [メソッド](@ref)の両方もかかわり、独自の章を立てて解説するほど十分重要です[Constructors](@ref man-constructors)。
 
+[](## Mutable Composite Types)
+## 可変複合型
+
+
+```@raw html
+<!--
 If a composite type is declared with `mutable struct` instead of `struct`, then instances of
 it can be modified:
+-->
+```
+`struct`の代わりに`mutable struct`で複合型を宣言すると、インスタンスは変更可能になります。
 
-```jldoctest bartype
+
+```jldoctest
+ bartype
 julia> mutable struct Bar
            baz
            qux::Float64
        end
-
 julia> bar = Bar("Hello", 1.5);
 
 julia> bar.qux = 2.0
@@ -424,6 +806,9 @@ julia> bar.baz = 1//2
 1//2
 ```
 
+
+```@raw html
+<!--
 In order to support mutation, such objects are generally allocated on the heap, and have
 stable memory addresses.
 A mutable object is like a little container that might hold different values over time,
@@ -433,13 +818,32 @@ the field values alone tell you everything about the object.
 In deciding whether to make a type mutable, ask whether two instances
 with the same field values would be considered identical, or if they might need to change independently
 over time. If they would be considered identical, the type should probably be immutable.
+-->
+```
+変更に対応できるように、このようなオブジェクトは、一般にヒープ上に割り当てられ、メモリアドレスが一定しています。
+可変オブジェクトは、時間によって値の変わりうる小さなコンテナと似ていて、アドレスだけで確実に識別できます。
+対照的に、不変型のインスタンスは、特定のフィールド値に関連づけられています。
+フィールド値だけで、オブジェクトに関するすべてがわかります。
+型を可変にするかどうかを決めるには、同じフィールド値を持つ2つのインスタンスは同一だとみなせるか、あるいは時間とともに別々に変更する必要があるかを考えます。
+同一であるとみなせるならば、おそらくその型は不変にすべきでしょう。
 
+```@raw html
+<!--
 To recap, two essential properties define immutability in Julia:
 
   * An object with an immutable type is passed around (both in assignment statements and in function
     calls) by copying, whereas a mutable type is passed around by reference.
   * It is not permitted to modify the fields of a composite immutable type.
+-->
+```
+まとめ、Juliaにおいて不変性を定義する2つの本質的な特性：
 
+* 不変型のオブジェクトは、（代入文と関数呼び出しの両方で）コピーを受け渡ししますが、可変型の場合は参照を受け渡しします。
+* 不変な複合型のフィールドを変更することはできません。
+
+
+```@raw html
+<!--
 It is instructive, particularly for readers whose background is C/C++, to consider why these two
 properties go hand in hand.  If they were separated, i.e., if the fields of objects passed around
 by copying could be modified, then it would become more difficult to reason about certain instances
@@ -448,9 +852,21 @@ that the function changes a field: `x.isprocessed = true`.  Depending on whether
 by copying or by reference, this statement may or may not alter the actual argument in the calling
 routine.  Julia sidesteps the possibility of creating functions with unknown effects in this scenario
 by forbidding modification of fields of objects passed around by copying.
+-->
+```
+特にC/C++のことを知っている読者には、この2つの特性がどうして連携しているのか考えるとためになるでしょう。
+この2つが独立している場合、つまり、コピーによって渡されたオブジェクトのフィールドが可変の場合、汎化コードの特定のインスタンスについての推論は、より困難になります。
+たとえば`x`は関数の抽象型の引数で、関数のフィールドを以下のように変更したとします。
+`x.isprocessed = true`
+x`の渡し方がコピーか参照かによって、この文の呼び出し側ルーチンの実引数は変更されたりされなかったりします。
+Juliaでは、こんな場合に関数の引数がどう作用するのか分からなくなるのを避けるため、オブジェクトをコピー渡しする際のフィールドの変更は禁止されています。
 
-## Declared Types
+[](## Declared Types)
+## 宣言型
 
+
+```@raw html
+<!--
 The three kinds of types discussed in the previous three sections are actually all closely related.
 They share the same key properties:
 
@@ -458,9 +874,25 @@ They share the same key properties:
   * They have names.
   * They have explicitly declared supertypes.
   * They may have parameters.
+-->
+```
+前述の3セクションで説明した3種の型は、実のところ、すべて密接に関連しています。
+これらは重要な特徴が共通しています：
 
+* 明示的に宣言されている。
+* 名前がある。
+* 明示的にスーパータイプを宣言している。
+* パラメータを持ってもよい。
+
+
+```@raw html
+<!--
 Because of these shared properties, these types are internally represented as instances of the
 same concept, `DataType`, which is the type of any of these types:
+-->
+```
+特徴が共通しているため、これらの型は内部的に同じコンセプト`DataType`のインスタンスとして表現されます。
+`DataType`はこれらの型のいずれかのことです。
 
 ```jldoctest
 julia> typeof(Real)
@@ -470,16 +902,33 @@ julia> typeof(Int)
 DataType
 ```
 
+
+```@raw html
+<!--
 A `DataType` may be abstract or concrete. If it is concrete, it has a specified size, storage
 layout, and (optionally) field names. Thus a bits type is a `DataType` with nonzero size, but
 no field names. A composite type is a `DataType` that has field names or is empty (zero size).
 
 Every concrete value in the system is an instance of some `DataType`.
+-->
+```
+`DataType`は抽象型でも具象型でもかまいません。具象型であれば、特定のサイズ、 格納領域の配置 があり、（場合によっては）フィールド名もあります。
+そして、原始型は、サイズが0ではなく、フィールド名を持たない`DataType`です。
+複合型は、フィールド名を持つか、空（サイズ0）の`DataType`です。
 
-## Type Unions
+システムのあらゆる具体的な値は、なんらかの`DataType`のインスタンスです。
 
+[](## Type Unions)
+## 合併型
+
+
+```@raw html
+<!--
 A type union is a special abstract type which includes as objects all instances of any of its
 argument types, constructed using the special `Union` function:
+-->
+```
+合併型は特殊な抽象型で、引数のいずれかの型のインスタンスすべてをオブジェクトとして含み、特殊な関数`Union`を使って構築します。
 
 ```jldoctest
 julia> IntOrString = Union{Int,AbstractString}
@@ -495,11 +944,21 @@ julia> 1.0 :: IntOrString
 ERROR: TypeError: typeassert: expected Union{AbstractString, Int64}, got Float64
 ```
 
+
+```@raw html
+<!--
 The compilers for many languages have an internal union construct for reasoning about types; Julia
 simply exposes it to the programmer.
+-->
+```
+多くの言語のコンパイラには、型推論のための内部的な合併構造があります。Juliaは単にそれをプログラマに公開しているだけです。
 
-## Parametric Types
+[](## Parametric Types)
+## パラメトリック型
 
+
+```@raw html
+<!--
 An important and powerful feature of Julia's type system is that it is parametric: types can take
 parameters, so that type declarations actually introduce a whole family of new types -- one for
 each possible combination of parameter values. There are many languages that support some version
@@ -514,14 +973,40 @@ but will instead focus on explaining Julia's system in its own right. We will no
 because Julia is a dynamically typed language and doesn't need to make all type decisions at compile
 time, many traditional difficulties encountered in static parametric type systems can be relatively
 easily handled.
+-->
+```
 
+Juliaの型システムには、パラメトリックという重要かつ強力な特徴があります。
+型にパラメータをつけると、型宣言は実質的に、とりうるパラメータ組み合わせの分だけ、新しい型の一族を導入します。
+[汎化プログラミング](https://en.wikipedia.org/wiki/Generic_programming)では、必要な型を正確に指定しなくても、処理すべきデータ構造やアルゴリズムを特定することができて、多くの言語で、何らかの形で対応しています。
+たとえば、ML、Haskell、Ada、Eiffel、C ++、Java、C＃、F＃、およびScalaなど、少し挙げるだけでも、これだけの言語が何らかの形で汎化プログラミングを取り入れています。
+これらの言語の中には真のパラメトリック多相（ML、Haskell、Scalaなど）に対応するものもあれば、テンプレートベースの汎化プログラミング（C ++、Javaなど）のスタイルに対応するものもあります。
+言語によって汎化プログラミングやパラメトリック型は多種多様であるため、Juliaのパラメトリック型を他の言語と比較することはせず、Julia自体のシステムについて説明することに専念します。
+しかし、Juliaは動的型付け言語で、コンパイル時にすべての型を決定する必要はないため、静的パラメトリック型付け言語の多くで生じる従来の困難が、比較的簡単に扱えることを注記しておきます。
+
+
+
+```@raw html
+<!--
 All declared types (the `DataType` variety) can be parameterized, with the same syntax in each
 case. We will discuss them in the following order: first, parametric composite types, then parametric
 abstract types, and finally parametric bits types.
+-->
+```
+すべての宣言型（`DataType`の仲間）は、それぞれ同じ構文でパラメータ化できます。
+まず、パラメトリック複合型、次にパラメトリック抽象型、最後にパラメトリック原始型という順番で説明します。[訳注2]_
 
-### Parametric Composite Types
+[](### Parametric Composite Types)
+### パラメトリック複合型
 
+
+```@raw html
+<!--
 Type parameters are introduced immediately after the type name, surrounded by curly braces:
+-->
+```
+
+型パラメータは、型名のすぐあとに、中括弧で囲んで挿入します。
 
 ```jldoctest pointtype
 julia> struct Point{T}
@@ -530,6 +1015,8 @@ julia> struct Point{T}
        end
 ```
 
+```@raw html
+<!--
 This declaration defines a new parametric type, `Point{T}`, holding two "coordinates" of type
 `T`. What, one may ask, is `T`? Well, that's precisely the point of parametric types: it can be
 any type at all (or a value of any bits type, actually, although here it's clearly used as a type).
@@ -537,6 +1024,16 @@ any type at all (or a value of any bits type, actually, although here it's clear
 of `Point` with [`Float64`](@ref). Thus, this single declaration actually declares an unlimited
 number of types: `Point{Float64}`, `Point{AbstractString}`, `Point{Int64}`, etc. Each of these
 is now a usable concrete type:
+-->
+```
+
+この宣言では、2つの型`T`の「座標」を保持している新しいパラメトリック型`Point{T}`を定義しています。
+`T`ってなんだ？と誰かが聞くかもしれません。これがまさしくパラメトリック型のポイントです。
+どんな型（本当は原始型の値でもいいですが、ここでは型が使われているのが明らかです）でもかまいません。
+ `Point{Float64}`は、`Point` の定義の中の`T`を [`Float64`](@ref)と置き換えて定義したのと同等な具象型です。
+ よって、一つの宣言が実質的には、`Point{Float64}`、`Point{AbstractString}`、`Point{Int64}`などの無限の宣言に相当します。
+ そして、それぞれが、具象型として利用可能です。
+
 
 ```jldoctest pointtype
 julia> Point{Float64}
@@ -546,11 +1043,20 @@ julia> Point{AbstractString}
 Point{AbstractString}
 ```
 
+
+```@raw html
+<!--
 The type `Point{Float64}` is a point whose coordinates are 64-bit floating-point values, while
 the type `Point{AbstractString}` is a "point" whose "coordinates" are string objects (see [Strings](@ref)).
 
 `Point` itself is also a valid type object, containing all instances `Point{Float64}`, `Point{AbstractString}`,
 etc. as subtypes:
+-->
+```
+`Point{Float64}`という型は、座標が64ビット浮動小数点数である点であり、`Point{AbstractString}`は、その「座標」が文字列オブジェクトである「点」です（ [文字列](@ref)を参照）。
+
+`Point`はこれ自体が妥当な型オブジェクトで、Point{Float64}`、 `Point{AbstractString}`などをすべてサブタイプとして含んでいます。
+
 
 ```jldoctest pointtype
 julia> Point{Float64} <: Point
@@ -560,7 +1066,14 @@ julia> Point{AbstractString} <: Point
 true
 ```
 
+
+```@raw html
+<!--
 Other types, of course, are not subtypes of it:
+-->
+```
+もちろん、他の型はこの型のサブタイプではありません：
+
 
 ```jldoctest pointtype
 julia> Float64 <: Point
@@ -570,7 +1083,13 @@ julia> AbstractString <: Point
 false
 ```
 
+
+```@raw html
+<!--
 Concrete `Point` types with different values of `T` are never subtypes of each other:
+-->
+```
+`T`の値が異なる具象型`Point`は、決して互いにサブタイプではありません。
 
 ```jldoctest pointtype
 julia> Point{Float64} <: Point{Int64}
@@ -580,21 +1099,47 @@ julia> Point{Float64} <: Point{Real}
 false
 ```
 
+
+```@raw html
+<!--
 !!! warning
     This last point is *very* important: even though `Float64 <: Real` we **DO NOT** have `Point{Float64} <: Point{Real}`.
+-->
+```
+!!!警告
+ この最後の点は**非常に**重要です。`Float64 <: Real`は成り立つにもかかわらず、`Point{Float64} <: Point{Real}`は成り立ちません。
 
+```@raw html
+<!--
 In other words, in the parlance of type theory, Julia's type parameters are *invariant*, rather
 than being [covariant (or even contravariant)](https://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29). This is for practical reasons: while any instance
 of `Point{Float64}` may conceptually be like an instance of `Point{Real}` as well, the two types
 have different representations in memory:
+-->
+```
+換言すると、型理論の術語では、Juliaの型パラメータは [共変（または反変）](https://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29)ではなく、不変です。
+これは現実的な理由によるもので、概念的には、`Point{Float64}`のインスタンスは`Point{Real}` のインスタンスと似ていますが、２つ型のメモリ内の表現は異なります。
 
+
+
+```@raw html
+<!--
   * An instance of `Point{Float64}` can be represented compactly and efficiently as an immediate pair
     of 64-bit values;
   * An instance of `Point{Real}` must be able to hold any pair of instances of [`Real`](@ref).
     Since objects that are instances of `Real` can be of arbitrary size and structure, in
     practice an instance of `Point{Real}` must be represented as a pair of pointers to
     individually allocated `Real` objects.
+-->
+```
 
+* `Point{Float64}`のインスタンスは、64ビット値の隣接するペアとして密集して効率的に表現できます。
+* `Point{Real}` のインスタンスは、どんな[`Real`](@ref)のペアでも保持できる必要があります。`Real`のインスタンスとなるオブジェクトは任意のサイズと構造になる可能性があるので、現実的には、`Point{Real}`のインスタンスは、個別に割り当てられた`Real`オブジェクトへのポインタのペアとして表現する必要があります。
+
+
+
+```@raw html
+<!--
 The efficiency gained by being able to store `Point{Float64}` objects with immediate values is
 magnified enormously in the case of arrays: an `Array{Float64}` can be stored as a contiguous
 memory block of 64-bit floating-point values, whereas an `Array{Real}` must be an array of pointers
@@ -602,9 +1147,20 @@ to individually allocated [`Real`](@ref) objects -- which may well be
 [boxed](https://en.wikipedia.org/wiki/Object_type_%28object-oriented_programming%29#Boxing)
 64-bit floating-point values, but also might be arbitrarily large, complex objects, which are
 declared to be implementations of the `Real` abstract type.
+-->
+```
+`Point{Float64}`オブジェクトに、値を直接を格納できると、得られる効率は、配列の場合、非常に大きくなります。
+`Array{Float64}`は、64ビットの浮動小数点数の連続したメモリブロックとして格納されますが、`Array{Real}`は[`Real`](@ref) オブジェクトにそれぞれ割り当てられたポインタの配列でなければなりません。
+ 64ビットの浮動小数点数が[ボックス化](https://en.wikipedia.org/wiki/Object_type_%28object-oriented_programming%29#Boxing)されていても構いませんが、抽象型`Real`の実装として宣言された任意の大きさの複素数オブジェクトでもかまいません。
 
+```@raw html
+<!--
 Since `Point{Float64}` is not a subtype of `Point{Real}`, the following method can't be applied
 to arguments of type `Point{Float64}`:
+-->
+```
+`Point{Float64}`は、`Point{Real}`のサブタイプではないので、以下のメソッドを型`Point{Float64}`の引数に適用することはできません。
+
 
 ```julia
 function norm(p::Point{Real})
@@ -612,8 +1168,15 @@ function norm(p::Point{Real})
 end
 ```
 
+
+```@raw html
+<!--
 A correct way to define a method that accepts all arguments of type `Point{T}` where `T` is
 a subtype of [`Real`](@ref) is:
+-->
+```
+`T`が[`Real`](@ref)のサブタイプである`Point{T}`という型のすべてを、引数として受け入れるメソッドを定義する正しい方法は次のとおりです。
+
 
 ```julia
 function norm(p::Point{<:Real})
@@ -621,19 +1184,37 @@ function norm(p::Point{<:Real})
 end
 ```
 
+
+```@raw html
+<!--
 (Equivalently, one could define `function norm{T<:Real}(p::Point{T})` or
 `function norm(p::Point{T} where T<:Real)`; see [UnionAll Types](@ref).)
 
 More examples will be discussed later in [Methods](@ref).
+-->
+```
+（同等の定義として、`function norm{T<:Real}(p::Point{T})`や、`function norm(p::Point{T} where T<:Real)`があります。（[全合併型](@ref) を参照。）
 
+より多くの例については、後の [メソッド](@ref) で説明します。
+
+```@raw html
+<!--
 How does one construct a `Point` object? It is possible to define custom constructors for composite
 types, which will be discussed in detail in [Constructors](@ref man-constructors), but in the absence of any special
 constructor declarations, there are two default ways of creating new composite objects, one in
 which the type parameters are explicitly given and the other in which they are implied by the
 arguments to the object constructor.
-
+-->
+```
+`Point`オブジェクトはどのように構成するのでしょうか？
+[コンストラクタ]（@ ref man-constructor）で詳しく説明しますが、複合型に独自のコンストラクタを定義することは可能ですが、特別にコンストラクタの宣言をしなくても、デフォルトで新しい複合型オブジェクトを作成する方法が2通りあります。1つは型パラメータを明示的に与えるもの、もう1つはオブジェクトコンストラクタへの引数から暗黙裡に推定されるものです。
+```@raw html
+<!--
 Since the type `Point{Float64}` is a concrete type equivalent to `Point` declared with [`Float64`](@ref)
 in place of `T`, it can be applied as a constructor accordingly:
+-->
+```
+型`Point{Float64}`は、`T`に[`Float64`](@ref) を代入して宣言した`Point`と同等の具象型なので、`Point`と同様のコンストラクタとして適用できます。
 
 ```jldoctest pointtype
 julia> Point{Float64}(1.0, 2.0)
@@ -643,7 +1224,15 @@ julia> typeof(ans)
 Point{Float64}
 ```
 
+
+```@raw html
+<!--
 For the default constructor, exactly one argument must be supplied for each field:
+-->
+```
+デフォルトのコンストラクタには、各フィールドにちょうど1つの引数を指定する必要があります。
+
+
 
 ```jldoctest pointtype
 julia> Point{Float64}(1.0)
@@ -657,6 +1246,9 @@ julia> Point{Float64}(1.0,2.0,3.0)
 ERROR: MethodError: no method matching Point{Float64}(::Float64, ::Float64, ::Float64)
 ```
 
+
+```@raw html
+<!--
 Only one default constructor is generated for parametric types, since overriding it is not possible.
 This constructor accepts any arguments and converts them to the field types.
 
@@ -664,6 +1256,13 @@ In many cases, it is redundant to provide the type of `Point` object one wants t
 the types of arguments to the constructor call already implicitly provide type information. For
 that reason, you can also apply `Point` itself as a constructor, provided that the implied value
 of the parameter type `T` is unambiguous:
+-->
+```
+パラメトリック型に対しては、デフォルトのコンストラクタは1つしか生成されません。オーバーライドできないためです。このコンストラクタは任意の引数を受け取り、フィールドの型に変換します。
+
+多くの場合、生成したい`Point`オブジェクトの型を指定するのは冗長です。
+`Point`コンストラクタを呼び出す時の引数に、すでに型情報が隠されているからです。
+そのため、`Point`のパラメータの型`T`が推定可能で曖昧さがない場合は、`Point`自体をコンストラクタとして適用することも可能です。
 
 ```jldoctest pointtype
 julia> Point(1.0,2.0)
@@ -679,8 +1278,15 @@ julia> typeof(ans)
 Point{Int64}
 ```
 
+
+```@raw html
+<!--
 In the case of `Point`, the type of `T` is unambiguously implied if and only if the two arguments
 to `Point` have the same type. When this isn't the case, the constructor will fail with a [`MethodError`](@ref):
+-->
+```
+
+`Point`の場合、2つの引数が同じ型を持つ場合にのみ、型`T`は明確に推定されます。これ以外の場合、コンストラクタは失敗して、 [`MethodError`](@ref) が発生します。
 
 ```jldoctest pointtype
 julia> Point(1,2.5)
@@ -689,20 +1295,41 @@ Closest candidates are:
   Point(::T, !Matched::T) where T at none:2
 ```
 
+
+```@raw html
+<!--
 Constructor methods to appropriately handle such mixed cases can be defined, but that will not
 be discussed until later on in [Constructors](@ref man-constructors).
+-->
+```
+このような型の混ざった場合を適切に扱うコンストラクタメソッドは定義できますが、後の[コンストラクタ]（@ ref man-constructors）まで議論を保留します。
 
-### Parametric Abstract Types
+[](### Parametric Abstract Types)
+### パラメトリック抽象型
 
+
+```@raw html
+<!--
 Parametric abstract type declarations declare a collection of abstract types, in much the same
 way:
+-->
+```
+パラメトリック抽象型に対しても、ほぼ同じ方法で、抽象型の一群に対して型宣言を行います。
 
 ```jldoctest pointytype
 julia> abstract type Pointy{T} end
 ```
 
+
+```@raw html
+<!--
 With this declaration, `Pointy{T}` is a distinct abstract type for each type or integer value
 of `T`. As with parametric composite types, each such instance is a subtype of `Pointy`:
+-->
+```
+
+この宣言では`Pointy{T}`は、型や整数値を表す`T`それぞれに対して別々の抽象型になります。
+パラメトリック複合型と同様に、各インスタンスは`Pointy`のサブタイプです。
 
 ```jldoctest pointytype
 julia> Pointy{Int64} <: Pointy
@@ -712,8 +1339,13 @@ julia> Pointy{1} <: Pointy
 true
 ```
 
-Parametric abstract types are invariant, much as parametric composite types are:
 
+```@raw html
+<!--
+Parametric abstract types are invariant, much as parametric composite types are:
+-->
+```
+パラメトリックな抽象型は、パラメトリックな複合型と同じように不変です。
 ```jldoctest pointytype
 julia> Pointy{Float64} <: Pointy{Real}
 false
@@ -722,9 +1354,17 @@ julia> Pointy{Real} <: Pointy{Float64}
 false
 ```
 
+
+```@raw html
+<!--
 The notation `Pointy{<:Real}` can be used to express the Julia analogue of a
 *covariant* type, while `Pointy{>:Int}` the analogue of a *contravariant* type,
 but technically these represent *sets* of types (see [UnionAll Types](@ref)).
+-->
+```
+Juliaでは、`Pointy{<:Real}`という表記で**共変**型のようなもの、`Pointy{>:Int}`で**反変**型のようなものを表現できます。
+しかし、専門的には、これらは型の**集合**を表しています。([全合併型](@ref) 参照)
+
 ```jldoctest pointytype
 julia> Pointy{Float64} <: Pointy{<:Real}
 true
@@ -733,9 +1373,17 @@ julia> Pointy{Real} <: Pointy{>:Int}
 true
 ```
 
+
+```@raw html
+<!--
 Much as plain old abstract types serve to create a useful hierarchy of types over concrete types,
 parametric abstract types serve the same purpose with respect to parametric composite types. We
 could, for example, have declared `Point{T}` to be a subtype of `Pointy{T}` as follows:
+-->
+```
+普通の抽象型は、具象型に対して役に立つ型の階層を作成するのに役立ちますが、パラメトリックな抽象型はパラメトリックな複合型と同じような目的で使います。
+たとえば、次のように`Point{T}`を`Pointy{T}`のサブタイプとして宣言することができます。
+
 
 ```jldoctest pointytype
 julia> struct Point{T} <: Pointy{T}
@@ -744,7 +1392,14 @@ julia> struct Point{T} <: Pointy{T}
        end
 ```
 
+
+```@raw html
+<!--
 Given such a declaration, for each choice of `T`, we have `Point{T}` as a subtype of `Pointy{T}`:
+-->
+```
+この宣言で、それぞれ選んた`T`に対して、`Point{T}`は`Pointy{T}`のサブタイプとなります。
+
 
 ```jldoctest pointytype
 julia> Point{Float64} <: Pointy{Float64}
@@ -757,7 +1412,13 @@ julia> Point{AbstractString} <: Pointy{AbstractString}
 true
 ```
 
+
+```@raw html
+<!--
 This relationship is also invariant:
+-->
+```
+この関係も不変です。
 
 ```jldoctest pointytype
 julia> Point{Float64} <: Pointy{Real}
@@ -767,9 +1428,17 @@ julia> Point{Float64} <: Pointy{<:Real}
 true
 ```
 
+
+```@raw html
+<!--
 What purpose do parametric abstract types like `Pointy` serve? Consider if we create a point-like
 implementation that only requires a single coordinate because the point is on the diagonal line
 *x = y*:
+-->
+```
+
+`Pointy`のようなパラメトリック抽象型はなんの役に立つのでしょうか？
+対角線**x = y**上にあるため、座標が1つ分かればすむ点のようなものを実装する場合を考えましょう。
 
 ```jldoctest pointytype
 julia> struct DiagPoint{T} <: Pointy{T}
@@ -777,21 +1446,46 @@ julia> struct DiagPoint{T} <: Pointy{T}
        end
 ```
 
+
+```@raw html
+<!--
 Now both `Point{Float64}` and `DiagPoint{Float64}` are implementations of the `Pointy{Float64}`
 abstraction, and similarly for every other possible choice of type `T`. This allows programming
 to a common interface shared by all `Pointy` objects, implemented for both `Point` and `DiagPoint`.
 This cannot be fully demonstrated, however, until we have introduced methods and dispatch in the
 next section, [Methods](@ref).
+-->
+```
 
+ここで`Point{Float64}`と`DiagPoint{Float64}`は共に、抽象型`Pointy{Float64}`の実装で、これは`T`に他の可能な型を代入しても同様です。
+これにより`Point`と`DiagPoint`のどちらを実装するにも、`Pointy`オブジェクトを共通のインタフェースにするようなプログラミングが可能になります。
+しかし、完全な解説は、メソッドとディスパッチを導入する次の章[メソッド](@ref) に持ち越します。
+
+
+
+```@raw html
+<!--
 There are situations where it may not make sense for type parameters to range freely over all
 possible types. In such situations, one can constrain the range of `T` like so:
+-->
+```
+
+型のパラメータがとりうる型を自由にしてしまうと、意味を成さない場合があります。
+そのような状況では、次のように、`T`の範囲を制限することができます。
+
 
 ```jldoctest realpointytype
 julia> abstract type Pointy{T<:Real} end
 ```
 
+
+```@raw html
+<!--
 With such a declaration, it is acceptable to use any type that is a subtype of
 [`Real`](@ref) in place of `T`, but not types that are not subtypes of `Real`:
+-->
+```
+この宣言では、`T`は任意の[`Real`](@ref)のサブタイプが受け入れますが、 `Real`のサブタイプでなければ受け入れません。
 
 ```jldoctest realpointytype
 julia> Pointy{Float64}
@@ -807,8 +1501,14 @@ julia> Pointy{1}
 ERROR: TypeError: Pointy: in T, expected T<:Real, got Int64
 ```
 
-Type parameters for parametric composite types can be restricted in the same manner:
 
+```@raw html
+<!--
+Type parameters for parametric composite types can be restricted in the same manner:
+-->
+```
+パラメトリック複合型の型パラメータも、同じ方法で制限できます
+。
 ```julia
 struct Point{T<:Real} <: Pointy{T}
     x::T
@@ -816,10 +1516,17 @@ struct Point{T<:Real} <: Pointy{T}
 end
 ```
 
+
+```@raw html
+<!--
 To give a real-world example of how all this parametric type machinery can be useful, here is
 the actual definition of Julia's [`Rational`](@ref) immutable type (except that we omit the
 constructor here for simplicity), representing an exact ratio of integers:
-
+-->
+```
+現実の世界でパラメトリック型という仕組みがどれほど役立つかという例として、
+ここでは整数の比を表す[`Rational`](@ref) という不変型の、Juliaでの実際の定義を示します。
+（単純化のため、ここではコンストラクタを省略します）
 ```julia
 struct Rational{T<:Integer} <: Real
     num::T
@@ -827,16 +1534,34 @@ struct Rational{T<:Integer} <: Real
 end
 ```
 
+
+```@raw html
+<!--
 It only makes sense to take ratios of integer values, so the parameter type `T` is restricted
 to being a subtype of [`Integer`](@ref), and a ratio of integers represents a value on the
 real number line, so any [`Rational`](@ref) is an instance of the [`Real`](@ref) abstraction.
+-->
+```
+整数値の比率になる時だけ、意味をなすので、パラメータの型`T`は、[`Integer`](@ref)のサブタイプに限定されています。
+整数の比は数直線上の値を表現するので、任意の[`Rational`](@ref) は、抽象型 [`Real`](@ref) のインスタンスです。
 
-### Tuple Types
+[](### Tuple Types)
+### タプル型
 
+
+
+```@raw html
+<!--
 Tuples are an abstraction of the arguments of a function -- without the function itself. The salient
 aspects of a function's arguments are their order and their types. Therefore a tuple type is similar
 to a parameterized immutable type where each parameter is the type of one field. For example,
 a 2-element tuple type resembles the following immutable type:
+-->
+```
+タプルとは関数本体からその引数だけを抜き出したものです。
+関数の引数の目立った特徴は、順序と型です。
+そのため、タプル型は、不変なパラメトリック複合型で各パラメータがフィールドの型に対応しているものと似ています。
+たとえば、2要素タプル型は、次の複合型に似ています。
 
 ```julia
 struct Tuple2{A,B}
@@ -845,6 +1570,9 @@ struct Tuple2{A,B}
 end
 ```
 
+
+```@raw html
+<!--
 However, there are three key differences:
 
   * Tuple types may have any number of parameters.
@@ -852,16 +1580,38 @@ However, there are three key differences:
     `Tuple{Any}` is considered an abstract type, and tuple types are only concrete if their parameters
     are.
   * Tuples do not have field names; fields are only accessed by index.
+-->
+```
+ただし、3つの重要な違いがあります。 
 
+* タプル型は、任意の数のパラメータを持つことができます。
+* タプル型は、そのパラメータと**共変**です。`Tuple{Int}`は`Tuple{Any}`のサブタイプです。したがって `Tuple{Any}`は、抽象型と見なされます。タプル型は、そのパラメータが具象型の場合にのみ具象型です。
+* タプルにはフィールド名はありません。フィールドにはインデックスによってのみアクセスできます。
+
+
+```@raw html
+<!--
 Tuple values are written with parentheses and commas. When a tuple is constructed, an appropriate
 tuple type is generated on demand:
+-->
+```
+タプルの値は、括弧とカンマをつかって書きます。タプルが生成されると、必要に応じて適切なタプル型が生成されます。
+
+
 
 ```jldoctest
 julia> typeof((1,"foo",2.5))
 Tuple{Int64,String,Float64}
 ```
 
+
+```@raw html
+<!--
 Note the implications of covariance:
+-->
+```
+
+暗黙的に共変となる点に注目してください。
 
 ```jldoctest
 julia> Tuple{Int,AbstractString} <: Tuple{Real,Any}
@@ -874,13 +1624,27 @@ julia> Tuple{Int,AbstractString} <: Tuple{Real,}
 false
 ```
 
+
+```@raw html
+<!--
 Intuitively, this corresponds to the type of a function's arguments being a subtype of the function's
 signature (when the signature matches).
+-->
+```
 
-### Vararg Tuple Types
+直観的には、これは、関数の引数の型が関数のシグネチャのサブタイプであることに相当します（シグネチャが適合する場合）。
 
+[](### Vararg Tuple Types)
+### 可変引数タプル型
+
+
+```@raw html
+<!--
 The last parameter of a tuple type can be the special type `Vararg`, which denotes any number
 of trailing elements:
+-->
+```
+タプル型の最後のパラメータは、特殊な型である`可変引数`として、任意の数の後続の要素を示す型とすることができます。
 
 ```jldoctest
 julia> mytupletype = Tuple{AbstractString,Vararg{Int}}
@@ -899,17 +1663,37 @@ julia> isa(("1",1,2,3.0), mytupletype)
 false
 ```
 
+
+```@raw html
+<!--
 Notice that `Vararg{T}` corresponds to zero or more elements of type `T`. Vararg tuple types are
 used to represent the arguments accepted by varargs methods (see [可変引数関数](@ref)).
 
 The type `Vararg{T,N}` corresponds to exactly `N` elements of type `T`.  `NTuple{N,T}` is a convenient
 alias for `Tuple{Vararg{T,N}}`, i.e. a tuple type containing exactly `N` elements of type `T`.
+-->
+```
+`Vararg{T}`は、0個以上の型`T`に対応することに注意してください。
+可変引数タプル型は、varargsメソッドによって受け入れられる引数を表すために使用されます（[可変引数関数](@ref)を参照）。
 
-#### [Singleton Types](@id man-singleton-types)
+型`Vararg{T,N}`は、ちょうど`N`個の型`T`に対応します。
+`NTuple{N,T}`は`Tuple{Vararg{T,N}}`の便利なエイリアスです。
+つまり、型`T`の要素をちょうど`N`個含むタプル型です。
 
+[](#### [Singleton Types](@id man-singleton-types))
+#### [シングルトン型](@id man-singleton-types)
+
+
+```@raw html
+<!--
 There is a special kind of abstract parametric type that must be mentioned here: singleton types.
 For each type, `T`, the "singleton type" `Type{T}` is an abstract type whose only instance is
 the object `T`. Since the definition is a little difficult to parse, let's look at some examples:
+-->
+```
+ここで、特殊なパラメトリック抽象型であるシングルトン型について触れておくべきでしょう。
+型`T`それぞれに対して、 「シングルトン型」 `Type{T}`は、インスタンスが`T`唯一つだけの抽象型です。
+定義を構文的に説明するのは少し難しいので、例をいくつか見てみましょう。
 
 ```jldoctest
 julia> isa(Float64, Type{Float64})
@@ -925,9 +1709,18 @@ julia> isa(Float64, Type{Real})
 false
 ```
 
+
+```@raw html
+<!--
 In other words, [`isa(A,Type{B})`](@ref) is true if and only if `A` and `B` are the same object
 and that object is a type. Without the parameter, `Type` is simply an abstract type which has
 all type objects as its instances, including, of course, singleton types:
+-->
+```
+
+換言すると、[`isa(A,Type{B})`](@ref) は、`A`と`B`が同じオブジェクトであり、そのオブジェクトとは型であるのみ真になります。
+パラメータをつけない`Type`は、単なる抽象型であり、すべての型オブジェクトは`Type`のインスタンスです（もちろん、シングルトン型も含みます）。
+
 
 ```jldoctest
 julia> isa(Type{Float64}, Type)
@@ -940,7 +1733,15 @@ julia> isa(Real, Type)
 true
 ```
 
+
+```@raw html
+<!--
 Any object that is not a type is not an instance of `Type`:
+-->
+```
+型ではないオブジェクトは、`Type`のインスタンスではありません。
+
+
 
 ```jldoctest
 julia> isa(1, Type)
@@ -950,21 +1751,45 @@ julia> isa("foo", Type)
 false
 ```
 
+
+```@raw html
+<!--
 Until we discuss [Parametric Methods](@ref) and [conversions](@ref conversion-and-promotion), it is difficult to explain
 the utility of the singleton type construct, but in short, it allows one to specialize function
 behavior on specific type *values*. This is useful for writing methods (especially parametric
 ones) whose behavior depends on a type that is given as an explicit argument rather than implied
 by the type of one of its arguments.
+-->
+```
+[パラメトリックメソッド](@ref)と[変換](@ref conversion-and-promotion)の議論がすむまで、
+シングルトン型がどう役に立つのかを説明するのは難しいですが、手短にいうと、関数の挙動を特定の型の**値**だけに特化することができるのです。
+これが役に立つのは、挙動が型に依存する（特にパラメトリックな）メソッドを書く時で、
+しかもその型が勝手に推測されるのではなく、わざわざ引数として与える場合です。
 
+```@raw html
+<!--
 A few popular languages have singleton types, including Haskell, Scala and Ruby. In general usage,
 the term "singleton type" refers to a type whose only instance is a single value. This meaning
 applies to Julia's singleton types, but with that caveat that only type objects have singleton
 types.
+-->
+```
+Haskell、Scala、Rubyなどの人気のある言語には、シングルトン型が備わっています。
+通常の用法では、「シングルトン型」という術語は、唯一のインスタンスがで単一の値である型を指します。
+この意味はJuliaのシングルトン型にも当てはまりますが、型オブジェクトだけがシングルトン型になるという点に注意してください。
 
-### Parametric Primitive Types
+[](### Parametric Primitive Types)
+### パラメトリック原始型
 
+
+```@raw html
+<!--
 Primitive types can also be declared parametrically. For example, pointers are represented as
 primitive types which would be declared in Julia like this:
+-->
+```
+原始型にもパラメータをつけて宣言することができます。
+たとえば、ポインタは原始型として表現できて、Juliaでは以下のように宣言します。
 
 ```julia
 # 32-bit system:
@@ -974,12 +1799,21 @@ primitive type Ptr{T} 32 end
 primitive type Ptr{T} 64 end
 ```
 
+
+```@raw html
+<!--
 The slightly odd feature of these declarations as compared to typical parametric composite types,
 is that the type parameter `T` is not used in the definition of the type itself -- it is just
 an abstract tag, essentially defining an entire family of types with identical structure, differentiated
 only by their type parameter. Thus, `Ptr{Float64}` and `Ptr{Int64}` are distinct types, even though
 they have identical representations. And of course, all specific pointer types are subtypes of
 the umbrella `Ptr` type:
+-->
+```
+一般的なパラメトリック複合型と比べて、この宣言のちょっと変な特徴は、型パラメータ`T`が型自体の定義に使われていないことです。
+つまり、型パラメータは抽象的なタグであり、本質的に同一の構造である型の族全体をに定義し、型パラメータだけで差別化されています。
+そのため、`Ptr{Float64}`と`Ptr{Int64}`は、表現は同一であっても、型としては異なります。
+もちろん、個別のポインタ型はすべて、包括型`Ptr`のサブタイプです。
 
 ```jldoctest
 julia> Ptr{Float64} <: Ptr
@@ -989,21 +1823,45 @@ julia> Ptr{Int64} <: Ptr
 true
 ```
 
-## UnionAll Types
+[](## UnionAll Types)
+## 全合併型
 
+```@raw html
+<!--
 We have said that a parametric type like `Ptr` acts as a supertype of all its instances
 (`Ptr{Int64}` etc.). How does this work? `Ptr` itself cannot be a normal data type, since without
 knowing the type of the referenced data the type clearly cannot be used for memory operations.
 The answer is that `Ptr` (or other parametric types like `Array`) is a different kind of type called a
 `UnionAll` type. Such a type expresses the *iterated union* of types for all values of some parameter.
+-->
+```
+`Ptr`のようなパラメトリック型はすべてのインスタンス（`Ptr{Int64}`など）のスーパータイプのように振る舞うと前に述べましました。
+これはどのようにして実現しているのでしょうか？
+`Ptr`自体は通常のデータ型ではありえません。というのも、参照するデータの型が分からなければ、
+明らかに、その型を記憶操作に使用できないからです。
+答えは、`Ptr`の型（また他の`Array`のようなパラメトリック型）は、`全合併型`と呼ばれる種類の異なる型です 。
+この型は、あるパラメータをすべての値に対して**繰り返し合併した**型を表現します。
 
+```@raw html
+<!--
 `UnionAll` types are usually written using the keyword `where`. For example `Ptr` could be more
 accurately written as `Ptr{T} where T`, meaning all values whose type is `Ptr{T}` for some value
 of `T`. In this context, the parameter `T` is also often called a "type variable" since it is
 like a variable that ranges over types.
 Each `where` introduces a single type variable, so these expressions are nested for types with
 multiple parameters, for example `Array{T,N} where N where T`.
+-->
+```
+全合併型は、通常、キーワード`where`を使って記述されます。
+例えば、`Ptr`は、より正確には`Ptr{T} where T`と書くことができて、ある`T`という値によって`Ptr{T}`と書ける型をもつ値すべてを意味します。
+この文脈では、パラメータ`T`は型をまたぐ変数のようなものであるため、よく「型変数」と呼ばれます。
+それぞれの`where`は型変数を一つ導入するため、こういった式は複数のパラメータを持つ場合、
+例えば`Array{T,N} where N where T`のように、型に対してネストします。
 
+
+
+```@raw html
+<!--
 The type application syntax `A{B,C}` requires `A` to be a `UnionAll` type, and first substitutes `B`
 for the outermost type variable in `A`.
 The result is expected to be another `UnionAll` type, into which `C` is then substituted.
@@ -1012,7 +1870,21 @@ This explains why it is possible to partially instantiate a type, as in `Array{F
 parameter value has been fixed, but the second still ranges over all possible values.
 Using explicit `where` syntax, any subset of parameters can be fixed. For example, the type of all
 1-dimensional arrays can be written as `Array{T,1} where T`.
+-->
+```
+型の適用構文`A{B,C}`には、`A`が全合併型であることが必要です。
+まず`A`の一番外側の型変数を`B`で置換します。
+その結果は別の`全合併`型になることと想定されているので、`C`で置換します。
+よって`A{B,C}`と`A{B}{C}`は同等です。
+これは`Array{Float64}`のように、型を部分的にインスタンス化することができる理由の説明となっています。
+最初のパラメータの値は固定されていますが、2番目の値はすべてのとりうる値にまたがっているからです。
+明示的に`where`構文を使用すると、どんなパラメータの部分集合にでも固定できます。
+例えば、すべての1次元配列の型は、`Array{T,1} where T`と書くことができます。
 
+
+
+```@raw html
+<!--
 Type variables can be restricted with subtype relations.
 `Array{T} where T<:Integer` refers to all arrays whose element type is some kind of
 [`Integer`](@ref).
@@ -1022,14 +1894,36 @@ Type variables can have both lower and upper bounds.
 contain `Int`s (since `T` must be at least as big as `Int`).
 The syntax `where T>:Int` also works to specify only the lower bound of a type variable,
 and `Array{>:Int}` is equivalent to `Array{T} where T>:Int`.
+-->
+```
+型変数は、サブタイプの関係をつかって制限することができます。
+ `Array{T} where T<:Integer`は、配列で要素の型が[`Integer`](@ref)のいずれかになるものすべてを指しています。
+ 構文`Array{<:Integer}`は`Array{T} where T<:Integer`の便利な簡略表記です。
+ 型変数は、下限と上限の両方を指定することができます。
+  `Array{T} where Int<:T<:Number`は [`Number`](@ref)の配列で`Int`を含みうるものすべてを指します（少なくとも、`T` は`Int`以上の大きさでなければなりません）。
+  構文`where T>:Int`はまた、型変数の下限のみを指定していて、
+  `Array{>:Int}`は、`Array{T} where T>:Int`同等です。
 
+```@raw html
+<!--
 Since `where` expressions nest, type variable bounds can refer to outer type variables.
 For example `Tuple{T,Array{S}} where S<:AbstractArray{T} where T<:Real` refers to 2-tuples
 whose first element is some [`Real`](@ref), and whose second element is an `Array` of any
 kind of array whose element type contains the type of the first tuple element.
+-->
+```
+`where`式はネストするので、型変数を限定する式は外側の型変数を参照することができます。
+例えば、`Tuple{T,Array{S}} where S<:AbstractArray{T} where T<:Real`は、第1要素は[`Real`](@ref)のいずれかで、
+第2要素は、各要素が第1要素の型を含む型の配列である**配列**の、2要素-タプルを参照します。
 
+```@raw html
+<!--
 The `where` keyword itself can be nested inside a more complex declaration. For example,
 consider the two types created by the following declarations:
+-->
+```
+`where`キーワード自体は、より複雑な宣言の中でネストすることができます。
+たとえば、次の宣言で作成される2つの型を考えてみましょう。
 
 ```jldoctest
 julia> const T1 = Array{Array{T,1} where T, 1}
@@ -1039,18 +1933,35 @@ julia> const T2 = Array{Array{T,1}, 1} where T
 Array{Array{T,1},1} where T
 ```
 
+```@raw html
+<!--
 Type `T1` defines a 1-dimensional array of 1-dimensional arrays; each
 of the inner arrays consists of objects of the same type, but this type may vary from one inner array to the next.
 On the other hand, type `T2` defines a 1-dimensional array of 1-dimensional arrays all of whose inner arrays must have the
 same type.  Note that `T2` is an abstract type, e.g., `Array{Array{Int,1},1} <: T2`, whereas `T1` is a concrete type. As a consequence, `T1` can be constructed with a zero-argument constructor `a=T1()` but `T2` cannot.
+-->
+```
+型`T1`は、1次元配列を要素とする、1次元配列を定義します。
+内側の配列は同じ型のオブジェクトで構成されますが、この型は内側の配列ごとに異なる場合があります。
+一方、型`T2`は、すべての内側の配列の型が等しい1次元配列の1次元配列を定義します。
+`T2`は抽象型であり、`Array{Array{Int,1},1} <: T2`であるのに対して、`T1`は具象型である点に注意してください。
+したがって、`T1`は引数のないコンストラクタで`a=T1()`のように構築することはできますが、`T2`ではできません。
 
+```@raw html
+<!--
 There is a convenient syntax for naming such types, similar to the short form of function
 definition syntax:
+-->
+```
+このような型を命名する便利な構文があり、それは関数定義の短い形の構文と似ています：
 
 ```julia
 Vector{T} = Array{T,1}
 ```
 
+
+```@raw html
+<!--
 This is equivalent to `const Vector = Array{T,1} where T`.
 Writing `Vector{Float64}` is equivalent to writing `Array{Float64,1}`, and the umbrella type
 `Vector` has as instances all `Array` objects where the second parameter -- the number of array
@@ -1058,13 +1969,29 @@ dimensions -- is 1, regardless of what the element type is. In languages where p
 must always be specified in full, this is not especially helpful, but in Julia, this allows one
 to write just `Vector` for the abstract type including all one-dimensional dense arrays of any
 element type.
+-->
+```
+これは`const Vector = Array{T,1} where T`と同等です。
+`Vector{Float64}`と書くのは、`Array{Float64,1}`と書くのと同等です。
+包括型の `Vector`は、2番目のパラメータ（配列の次元数）が1である、すべての`Array`オブジェクトを、要素の種類に関係なく、インスタンスとして持ちます。
+パラメトリック型を常に完全に指定しなければならない言語では、こういう構文はそんなに有用ではないかもしれません。
+しかしJuliaでは、`Vector`と書くだけで、任意の要素型のすべての1次元の密な配列を含む抽象型を表すことができます。
 
-## Type Aliases
+[](## Type Aliases)
+## 型の別名
 
+
+```@raw html
+<!--
 Sometimes it is convenient to introduce a new name for an already expressible type.
 This can be done with a simple assignment statement.
 For example, `UInt` is aliased to either [`UInt32`](@ref) or [`UInt64`](@ref) as is
 appropriate for the size of pointers on the system:
+-->
+```
+すでに表現可能な型に新しい名前をつけると便利な場合が時々あります。
+これは簡単な代入文で行うことができます。
+たとえば、`UInt`は、システム上のポインタのサイズに応じて、[`UInt32`](@ref) か [`UInt64`](@ref)　の別名となります。
 
 ```julia-repl
 # 32-bit system:
@@ -1076,7 +2003,13 @@ julia> UInt
 UInt64
 ```
 
+
+```@raw html
+<!--
 This is accomplished via the following code in `base/boot.jl`:
+-->
+```
+これは`base/boot.jl`の中にある以下のコードで実現できます。
 
 ```julia
 if Int === Int64
@@ -1086,22 +2019,50 @@ else
 end
 ```
 
+
+```@raw html
+<!--
 Of course, this depends on what `Int` is aliased to -- but that is predefined to be the correct
 type -- either [`Int32`](@ref) or [`Int64`](@ref).
+-->
+```
+もちろん、これは `Int` が[`Int32`](@ref)と [`Int64`](@ref)のどちらの別名なのかでかわります。
+この別名は正しい型になるように事前に定義されています。
 
+```@raw html
+<!--
 (Note that unlike `Int`, `Float` does not exist as a type alias for a specific sized
 [`AbstractFloat`](@ref). Unlike with integer registers, the floating point register sizes
 are specified by the IEEE-754 standard. Whereas the size of `Int` reflects the size of a
 native pointer on that machine.)
+-->
+```
+（`Int`と違って、`Float`という、[`AbstractFloat`](@ref)の特定のサイズの型の別名は存在しない点に注意してください。
+整数レジスタとは異なり、浮動小数点レジスタのサイズは、IEEE-754規格で規定されています。
+一方`Int`のサイズは、そのマシン上のネイティブポインタのサイズを反映しています。）
 
-## Operations on Types
+[](## Operations on Types)
+## 型に対する演算
 
+
+```@raw html
+<!--
 Since types in Julia are themselves objects, ordinary functions can operate on them. Some functions
 that are particularly useful for working with or exploring types have already been introduced,
 such as the `<:` operator, which indicates whether its left hand operand is a subtype of its right
 hand operand.
+-->
+```
+Juliaの型はそれ自体がオブジェクトなので、通常の関数を作用させることができます。
+特に型の操作や探索に役立つ関数がいくつか既に導入されていて、
+`<:`などは、演算子の左側が右側のサブタイプであるかどうかを示す演算子です。
 
+```@raw html
+<!--
 The [`isa`](@ref) function tests if an object is of a given type and returns true or false:
+-->
+```
+[`isa`](@ref) 関数は、オブジェクトが指定された型であるかどうかを検査し、真か偽を返します。
 
 ```jldoctest
 julia> isa(1, Int)
@@ -1111,9 +2072,16 @@ julia> isa(1, AbstractFloat)
 false
 ```
 
+
+```@raw html
+<!--
 The [`typeof()`](@ref) function, already used throughout the manual in examples, returns the type
 of its argument. Since, as noted above, types are objects, they also have types, and we can ask
 what their types are:
+-->
+```
+[`typeof()`](@ref) 関数は、既にこのマニュアルを通して例として使っていますが、引数の型を返します。
+上記のように、型はオブジェクトであり、それ自体の型もあるので、型に対してその型が何であるかを尋ねることができます。
 
 ```jldoctest
 julia> typeof(Rational{Int})
@@ -1126,8 +2094,15 @@ julia> typeof(Union{Real,String})
 Union
 ```
 
+
+```@raw html
+<!--
 What if we repeat the process? What is the type of a type of a type? As it happens, types are
 all composite values and thus all have a type of `DataType`:
+-->
+```
+この操作を繰り返すとどうなるでしょうか？型の型の型は何でしょうか？
+既にみたように、型はすべて複合値なので、すべて`DataType`型になります。
 
 ```jldoctest
 julia> typeof(DataType)
@@ -1137,10 +2112,19 @@ julia> typeof(Union)
 DataType
 ```
 
+
+```@raw html
+<!--
 `DataType` is its own type.
 
 Another operation that applies to some types is [`supertype()`](@ref), which reveals a type's
 supertype. Only declared types (`DataType`) have unambiguous supertypes:
+-->
+```
+`DataType`は自身の型でもあります。
+
+別の一部の型に対する演算としては、[`supertype()`](@ref)は型のスーパータイプを示します。
+宣言型（`DataType`）のみが明確なスーパータイプを持っています：
 
 ```jldoctest
 julia> supertype(Float64)
@@ -1156,8 +2140,15 @@ julia> supertype(Any)
 Any
 ```
 
+
+```@raw html
+<!--
 If you apply [`supertype()`](@ref) to other type objects (or non-type objects), a [`MethodError`](@ref)
 is raised:
+-->
+```
+
+[`supertype()`](@ref) を他の型のオブジェクト（又は型ではないオブジェクト）に適用した場合は、[`MethodError`](@ref) が発生します。
 
 ```jldoctest
 julia> supertype(Union{Float64,Int64})
@@ -1167,11 +2158,20 @@ Closest candidates are:
   supertype(!Matched::UnionAll) at operators.jl:46
 ```
 
-## Custom pretty-printing
+[](## Custom pretty-printing)
+## 独自の出力整形
 
+
+```@raw html
+<!--
 Often, one wants to customize how instances of a type are displayed.  This is accomplished by
 overloading the [`show()`](@ref) function.  For example, suppose we define a type to represent
 complex numbers in polar form:
+-->
+```
+型のインスタンスがどのように表示されるかをカスタマイズしたい場合がよくおこります。
+これは、[`show()`](@ref) 関数のオーバーロードによって実現されます。
+たとえば、極座標形式で複素数を表す型を定義するとします。
 
 ```jldoctest polartype
 julia> struct Polar{T<:Real} <: Number
@@ -1183,6 +2183,9 @@ julia> Polar(r::Real,Θ::Real) = Polar(promote(r,Θ)...)
 Polar
 ```
 
+
+```@raw html
+<!--
 Here, we've added a custom constructor function so that it can take arguments of different
 [`Real`](@ref) types and promote them to a common type (see [Constructors](@ref man-constructors)
 and [Conversion and Promotion](@ref conversion-and-promotion)).
@@ -1190,15 +2193,28 @@ and [Conversion and Promotion](@ref conversion-and-promotion)).
 [`Number`](@ref), e.g. `+`, `*`, `one`, `zero`, promotion rules and so on.) By default,
 instances of this type display rather simply, with information about the type name and
 the field values, as e.g. `Polar{Float64}(3.0,4.0)`.
+-->
+```
+この例では、[`Real`](@ref)型の異なる引数をとると、それらを共通の型に昇格することができるような、独自のコンストラクタ関数を追加しました （ [コンストラクタ](@ref man-constructors)と[変換と昇格](@ref conversion-and-promotion)を参照)。
+（もちろん、[`Number`](@ref)型と同じように動作させるためには、他にも多くのメソッドを定義する必要があるでしょう
+（例えば、`+`、 `*`、 `one`、 `zero`、昇格のルールなど）。
+デフォルトでは、この型のインスタンスの表示はかなり単純で、型名とフィールド値を知らせるだけの、`Polar{Float64}(3.0,4.0)`のようになります。
 
+```@raw html
+<!--
 If we want it to display instead as `3.0 * exp(4.0im)`, we would define the following method to
 print the object to a given output object `io` (representing a file, terminal, buffer, etcetera;
 see [Networking and Streams](@ref)):
+-->
+```
+代わりに`3.0 * exp(4.0im)`のように表示したい場合は、オブジェクトを出力オブジェクト`io`（ファイル、端末、バッファなどを表します。[Networking and Streams](@ref) 参照）に出力する次のメソッドを定義します。
 
 ```jldoctest polartype
 julia> Base.show(io::IO, z::Polar) = print(io, z.r, " * exp(", z.Θ, "im)")
 ```
 
+```@raw html
+<!--
 More fine-grained control over display of `Polar` objects is possible. In particular, sometimes
 one wants both a verbose multi-line printing format, used for displaying a single object in the
 REPL and other interactive environments, and also a more compact single-line format used for
@@ -1206,13 +2222,25 @@ REPL and other interactive environments, and also a more compact single-line for
 by default the `show(io, z)` function is called in both cases, you can define a *different* multi-line
 format for displaying an object by overloading a three-argument form of `show` that takes the
 `text/plain` MIME type as its second argument (see [Multimedia I/O](@ref)), for example:
+-->
+```
+`Polar`オブジェクトの表示をより細かく制御することが可能です。
+特に、冗長な複数行印刷形式は、REPLなどの対話環境で単一のオブジェクトを表示する時に、簡単な単一行形式は、オブジェクトを別の（配列などの）オブジェクトの一部として表示する時にと 、両方を行いたい場合があります。
+デフォルトでは、`show(io, z)`関数が両方の場合に呼び出されますが、ユーザーが定義した**別の**複数行の形式を表示することもできます。そのためには、3引数の`show`関数で、2番目の引数に、`text/plain`MIMEタイプ（[Multimedia I/O](@ref)参照）をとるものをオーバーロードします。例えば、
 
 ```jldoctest polartype
 julia> Base.show{T}(io::IO, ::MIME"text/plain", z::Polar{T}) =
            print(io, "Polar{$T} complex number:\n   ", z)
 ```
 
+
+```@raw html
+<!--
 (Note that `print(..., z)` here will call the 2-argument `show(io, z)` method.) This results in:
+-->
+```
+
+（ここでは、`print(..., z)`は、2引数の`show(io, z)`メソッドを呼び出すことに注意してください）。この結果こうなります。
 
 ```jldoctest polartype
 julia> Polar(3, 4.0)
@@ -1225,14 +2253,29 @@ julia> [Polar(3, 4.0), Polar(4.0,5.3)]
  4.0 * exp(5.3im)
 ```
 
+
+```@raw html
+<!--
 where the single-line `show(io, z)` form is still used for an array of `Polar` values.   Technically,
 the REPL calls `display(z)` to display the result of executing a line, which defaults to `show(STDOUT, MIME("text/plain"), z)`,
 which in turn defaults to `show(STDOUT, z)`, but you should *not* define new [`display()`](@ref)
 methods unless you are defining a new multimedia display handler (see [Multimedia I/O](@ref)).
+-->
+```
+単一行の`show(io, z)`形式は、依然として、`Polar`の値の配列に使用されています。
+技術的には、REPLが、`display(z)`を呼び出して、実行結果の一行を表示します。
+冗長な複数行印刷形式は、`show(STDOUT, MIME("text/plain"), z)`が 、簡単な単一行形式は、`show(STDOUT, z)`がそれぞれデフォルトです。
+しかし、新しいマルチメディアディスプレイハンドラを定義する場合を除いて（[Multimedia I/O](@ref) 参照）、新たに[`display()`](@ref)メソッドを定義**すべきではありません**。
 
+```@raw html
+<!--
 Moreover, you can also define `show` methods for other MIME types in order to enable richer display
 (HTML, images, etcetera) of objects in environments that support this (e.g. IJulia).   For example,
 we can define formatted HTML display of `Polar` objects, with superscripts and italics, via:
+-->
+```
+さらに、`show`メソッドを他のMIMEタイプ向けに定義して、対応している環境（例えばIJulia）では、オブジェクトをよりリッチな表示（HTML、画像など）にすることもできます。
+たとえば、`Polar`書式付きのHTML表示を定義して、上付き文字と斜体を使うには、次のようにします。
 
 ```jldoctest polartype
 julia> Base.show{T}(io::IO, ::MIME"text/html", z::Polar{T}) =
@@ -1240,8 +2283,14 @@ julia> Base.show{T}(io::IO, ::MIME"text/html", z::Polar{T}) =
                    z.r, " <i>e</i><sup>", z.Θ, " <i>i</i></sup>")
 ```
 
+
+```@raw html
+<!--
 A `Polar` object will then display automatically using HTML in an environment that supports HTML
 display, but you can call `show` manually to get HTML output if you want:
+-->
+```
+`Polar`オブジェクトは、対応する環境ではHTMLを使用して自動的に表示されますが、必要なら手動で`show`を呼び出して、HTML出力することもできます。
 
 ```jldoctest polartype
 julia> show(STDOUT, "text/html", Polar(3.0,4.0))
@@ -1252,28 +2301,57 @@ julia> show(STDOUT, "text/html", Polar(3.0,4.0))
 <p>An HTML renderer would display this as: <code>Polar{Float64}</code> complex number: 3.0 <i>e</i><sup>4.0 <i>i</i></sup></p>
 ```
 
-## "Value types"
 
+[](## "Value types")
+## "値型"
+
+
+```@raw html
+<!--
 In Julia, you can't dispatch on a *value* such as `true` or `false`. However, you can dispatch
 on parametric types, and Julia allows you to include "plain bits" values (Types, Symbols, Integers,
 floating-point numbers, tuples, etc.) as type parameters.  A common example is the dimensionality
 parameter in `Array{T,N}`, where `T` is a type (e.g., [`Float64`](@ref)) but `N` is just an `Int`.
+-->
+```
+Juliaでは、`true` や `false`のような**値**によって、ディスパッチすることができません。
+しかし、パラメトリック型に対してはディスパッチができて、その型パラメータとして「プレーンビット」値（型、シンボル、整数、浮動小数点数、タプルなど）を使うことができます。
+よくある例として、`Array{T,N}`で使われる次元のパラメータがあり、この場合`T`は型（ [`Float64`](@ref)など）ですが、`N`はただの`Int`型です。
 
+
+
+```@raw html
+<!--
 You can create your own custom types that take values as parameters, and use them to control dispatch
 of custom types. By way of illustration of this idea, let's introduce a parametric type, `Val{T}`,
 which serves as a customary way to exploit this technique for cases where you don't need a more
 elaborate hierarchy.
 
 `Val` is defined as:
+-->
+```
+値をパラメータとする独自の型を作成して、その型によってディスパッチを制御することができます。
+この考え方を説明するために、パラメトリック型の`Val{T}`を導入しましょう。
+手の込んだ階層の必要ない時は、こうした手法にはこの型を慣用的に使います。
+
+`Val{T}`は次のように定義します。
 
 ```jldoctest valtype
 julia> struct Val{T}
        end
 ```
 
+
+```@raw html
+<!--
 There is no more to the implementation of `Val` than this.  Some functions in Julia's standard
 library accept `Val` types as arguments, and you can also use it to write your own functions.
  For example:
+-->
+```
+
+`Val`の実装は、これ以上はありません。
+Juliaの標準ライブラリの関数には`Val`型を引数にとるものもあり、また独自の関数を書く時にも、`Val`型は使えます。例えば、
 
 ```jldoctest valtype
 julia> firstlast(::Type{Val{true}}) = "First"
@@ -1289,22 +2367,53 @@ julia> firstlast(Val{false})
 "Last"
 ```
 
+
+```@raw html
+<!--
 For consistency across Julia, the call site should always pass a `Val`*type* rather than creating
 an *instance*, i.e., use `foo(Val{:bar})` rather than `foo(Val{:bar}())`.
+-->
+```
+Juliaでは一貫性を保つために、呼び出し側は、常に`Val`の**インスタンス**を作るのではなく、`Val`の**型**を渡す必要があります。
+つまり、`foo(Val{:bar}())`ではなく`foo(Val{:bar})`です。
 
+
+
+```@raw html
+<!--
 It's worth noting that it's extremely easy to mis-use parametric "value" types, including `Val`;
 in unfavorable cases, you can easily end up making the performance of your code much *worse*.
  In particular, you would never want to write actual code as illustrated above.  For more information
 about the proper (and improper) uses of `Val`, please read the more extensive discussion in [the performance tips](@ref man-performance-tips).
+-->
+```
+`Val`を含めて、パラメトリックな「値」型は非常に誤用しやすい点に注意してください。
+好ましくない場合には、コードのパフォーマンスを簡単に大幅に**悪化**させることもありえます。
+特に、上で説明したようなコードを実用のコードとして書きたいとは決して思わないでしょう。
+適切な（そして不適切な）`Val`の使い方の詳細については、[the performance tips](@ref man-performance-tips)の広範に渡る議論を読んでください。
 
-## [Nullable Types: Representing Missing Values](@id man-nullable-types)
 
+
+[](## [Nullable Types: Representing Missing Values](@id man-nullable-types))
+## [Null許容型: 欠損値の表現](@id man-nullable-types)
+
+
+```@raw html
+<!--
 In many settings, you need to interact with a value of type `T` that may or may not exist. To
 handle these settings, Julia provides a parametric type called [`Nullable{T}`](@ref), which can be thought
 of as a specialized container type that can contain either zero or one values. `Nullable{T}` provides
 a minimal interface designed to ensure that interactions with missing values are safe. At present,
 the interface consists of several possible interactions:
+-->
+```
+多くの状況で、あるのかどうか分からない、型が`T`の値を取り扱う必要があります。
+これらの状況を処理するために、Juliaでは、 [`Nullable{T}`](@ref)と呼ばれる、0個か1個の値を含む特殊なコンテナ型と考えることができる、パラメトリック型が用意されています。
+`Nullable{T}`には、欠損値のやりとりが安全にできることを保証するように設計された最小限のインターフェースがあります。
+このインタフェースはいくつかの関数から成り立っています。
 
+```@raw html
+<!--
   * Construct a `Nullable` object.
   * Check if a `Nullable` object has a missing value.
   * Access the value of a `Nullable` object with a guarantee that a [`NullException`](@ref)
@@ -1317,10 +2426,27 @@ the interface consists of several possible interactions:
     object, getting a result that is missing if either the `Nullable`
     itself was missing, or the test failed.
   * Perform general operations on single `Nullable` objects, propagating the missing data.
+-->
+```
 
-### Constructing [`Nullable`](@ref) objects
+* `Nullable`オブジェクトを構築します。
+* `Nullable`オブジェクトに欠損値があるかどうかを検査します。
+* `Nullable`オブジェクトにアクセスする場合に、オブジェクトの値が欠落している時は、[`NullException`](@ref)が投げられることを保証します。
+* `Nullable`オブジェクトにアクセスする場合に、オブジェクトの値が欠落している時は、型`T`のデフォルト値が返されることを保証します。
+* `Nullable`オブジェクトの値（存在する場合）に操作を実行し、`Nullable`の結果を取得します。元が欠損値の場合、結果も欠損値になります。
+* `Nullable`オブジェクトの値（存在する場合）に検査を実行し、`Nullable`オブジェクト自体が存在しないか、検査が失敗したかの結果を取得します。
+* 単一の`Nullable`オブジェクトに対して一般的な操作を実行し、欠落しているデータを伝播します。
 
+[](### Constructing [`Nullable`](@ref) objects)
+### [`Null許容`](@ref) オブジェクトの生成
+
+
+```@raw html
+<!--
 To construct an object representing a missing value of type `T`, use the `Nullable{T}()` function:
+-->
+```
+`T`型の欠損値を表すオブジェクトを作成するには、`Nullable{T}()`関数を使用します。
 
 ```jldoctest
 julia> x1 = Nullable{Int64}()
@@ -1333,8 +2459,14 @@ julia> x3 = Nullable{Vector{Int64}}()
 Nullable{Array{Int64,1}}()
 ```
 
+
+```@raw html
+<!--
 To construct an object representing a non-missing value of type `T`, use the `Nullable(x::T)`
 function:
+-->
+```
+`T`型の欠損していない値を表すオブジェクトを作成するには、次の`Nullable(x::T)` 関数を使用します。
 
 ```jldoctest
 julia> x1 = Nullable(1)
@@ -1347,13 +2479,27 @@ julia> x3 = Nullable([1, 2, 3])
 Nullable{Array{Int64,1}}([1, 2, 3])
 ```
 
+
+```@raw html
+<!--
 Note the core distinction between these two ways of constructing a `Nullable` object:
 in one style, you provide a type, `T`, as a function parameter; in the other style, you provide
 a single value of type `T` as an argument.
+-->
+```
+`Nullable`オブジェクトを構築するこれらの2つの方法の違いの核心に注目してください。
+一方は、型`T`を関数パラメータとして与えます。他方は型`T`の単一の値を引数として与えます。
 
-### Checking if a `Nullable` object has a value
+[](### Checking if a `Nullable` object has a value)
+### `Null許容`オブジェクトが値を持つかどうかを 検査する
 
+
+```@raw html
+<!--
 You can check if a `Nullable` object has any value using [`isnull()`](@ref):
+-->
+```
+`Nullable`オブジェクトに [`isnull()`](@ref) を使って値を持つかどうかを検査することができます。
 
 ```jldoctest
 julia> isnull(Nullable{Float64}())
@@ -1363,9 +2509,21 @@ julia> isnull(Nullable(0.0))
 false
 ```
 
-### Safely accessing the value of a `Nullable` object
+[](### Safely accessing the value of a `Nullable` object)
+### `Null許容`オブジェクトの値に安全にアクセスする
 
+```@raw html
+<!--
+-->
+```
+
+
+```@raw html
+<!--
 You can safely access the value of a `Nullable` object using [`get()`](@ref):
+-->
+```
+`Nullable`オブジェクトに [`get()`](@ref) を使って、オブジェクトの値に安全にアクセスできます。
 
 ```jldoctest
 julia> get(Nullable{Float64}())
@@ -1377,13 +2535,27 @@ julia> get(Nullable(1.0))
 1.0
 ```
 
+
+```@raw html
+<!--
 If the value is not present, as it would be for `Nullable{Float64}`, a [`NullException`](@ref)
 error will be thrown. The error-throwing nature of the `get()` function ensures that any
 attempt to access a missing value immediately fails.
+-->
+```
+`Nullable{Float64}`に値が存在しない場合は、[`NullException`](@ref) エラーが投げられます。
+エラーを投げるという意義から、`get()`関数を使って欠損値にアクセスしようとしても
+すぐに失敗することが保証されています。
 
+```@raw html
+<!--
 In cases for which a reasonable default value exists that could be used when a `Nullable`
 object's value turns out to be missing, you can provide this default value as a second argument
 to `get()`:
+-->
+```
+
+適切なデフォルト値がある場合、`Nullable` オブジェクト値の欠落が判明した時は、このデフォルト値を`get()`の2番目の引数に指定して利用できます。
 
 ```jldoctest
 julia> get(Nullable{Float64}(), 0.0)
@@ -1393,56 +2565,129 @@ julia> get(Nullable(1.0), 0.0)
 1.0
 ```
 
+
+```@raw html
+<!--
 !!! tip
     Make sure the type of the default value passed to `get()` and that of the `Nullable`
     object match to avoid type instability, which could hurt performance. Use [`convert()`](@ref)
     manually if needed.
+-->
+```
 
-### Performing operations on `Nullable` objects
+!!! ヒント 
+`get()`に渡すデフォルト値の型と、`Nullable`オブジェクトの型が一致しているのを確認して、型が不安定になるのを避けてください。パフォーマンスの低下につながるので、必要に応じて手動で[`convert()`](@ref)を使用してください。
 
+[](### Performing operations on `Nullable` objects)
+### `Null許容`オブジェクトの操作を実行する
+
+
+```@raw html
+<!--
 `Nullable` objects represent values that are possibly missing, and it
 is possible to write all code using these objects by first testing to see if
 the value is missing with [`isnull()`](@ref), and then doing an appropriate
 action. However, there are some common use cases where the code could be more
 concise or clear by using a higher-order function.
+-->
+```
+`Nullable`オブジェクトは欠落の可能性のある値を表しています。
+これらのオブジェクトを使用するコードを書く時すべてにおいて、まず値が欠落していないかどうかを[`isnull()`](@ref) で検査してから、適切な処置を行うことは可能です。
+しかし、高階関数を使うことで共通して、コードがより簡潔になったり明確になったりする事例がいくつかあります。
 
+
+
+```@raw html
+<!--
 The [`map`](@ref) function takes as arguments a function `f` and a `Nullable` value
 `x`. It produces a `Nullable`:
 
  - If `x` is a missing value, then it produces a missing value;
  - If `x` has a value, then it produces a `Nullable` containing
    `f(get(x))` as value.
+-->
+```
+ [`map`](@ref)関数は、引数として関数`f`と`Nullable`の値`x`を取ります。
+ そして、`Nullable`を生成します。
 
+ -   もし`x`が欠損値があれば、欠損値を生成する。
+ -   もし`x`が値を持っていれば、`f(get(x))`を値として含む`Nullable`を生成する 。
+
+
+
+```@raw html
+<!--
 This is useful for performing simple operations on values that might be missing
 if the desired behaviour is to simply propagate the missing values forward.
+-->
+```
+[`map`](@ref)関数が役に立つのは、欠損の可能性のある値に対して、単純な操作を実行し、欠損している場合には単に伝播するだけでよい場合です。
 
+```@raw html
+<!--
 The [`filter`](@ref) function takes as arguments a predicate function `p`
 (that is, a function returning a boolean) and a `Nullable` value `x`.
 It produces a `Nullable` value:
+
+
 
  - If `x` is a missing value, then it produces a missing value;
  - If `p(get(x))` is true, then it produces the original value `x`;
  - If `p(get(x))` is false, then it produces a missing value.
 
+-->
+```
+
+[`filter`](@ref)関数は、述語関数`p`（つまり、ブール値を返す関数）と`Nullable`の値`x`を引数としてとります。
+`Nullable`である値を生成します。
+
+   - もし`x`が欠損値があれば、欠損値を生成する。
+   - もし`p(get(x))`がtrueの場合、元の値`x`が生成されます。
+   - もし`p(get(x))`ががfalseの場合、欠損値が生成されます。
+
+
+```@raw html
+<!--
 In this way, `filter` can be thought of as selecting only allowable
 values, and converting non-allowable values to missing values.
+-->
+```
+このように、`filter`は許容できる値のみを選択し、許容できない値は欠損値に変換していると考えられます。
 
+
+```@raw html
+<!--
 While `map` and `filter` are useful in specific cases, by far the most useful
 higher-order function is [`broadcast`](@ref), which can handle a wide variety of cases,
 including making existing operations work and propagate `Nullable`s. An example
 will motivate the need for `broadcast`. Suppose we have a function that computes the
 greater of two real roots of a quadratic equation, using the quadratic formula:
+-->
+```
+
+特定の場合に`map`と`filter`は有用ですが、断然、最も有用な高階関数は[`broadcast`](@ref)です。
+`broadcast`は多様な場面で利用可能で、例えば、存在するデータには操作を行って、`Nullable`を伝播することができます。
+`broadcast()`の必要性がわかる例を挙げましょう。
+二次方程式の2つの実数根のうち大きい方を2次の公式を使って計算する関数があるとします。
 
 ```jldoctest nullableroot
 julia> root(a::Real, b::Real, c::Real) = (-b + √(b^2 - 4a*c)) / 2a
 root (generic function with 1 method)
 ```
 
+
+```@raw html
+<!--
 We may verify that the result of `root(1, -9, 20)` is `5.0`, as we expect,
 since `5.0` is the greater of two real roots of the quadratic equation.
+-->
+```
+`root(1, -9, 20)`の結果は`5.0`だと、予想どおりの確認ができるでしょう。`5.0`は二次方程式の二つの実根の大きい方だからです。
 
+```@raw html
+<!--
 Suppose now that we want to find the greatest real root of a quadratic
-equations where the coefficients might be missing values. Having missing values
+equations where the coefficients migt be missing values. Having missing values
 in datasets is a common occurrence in real-world data, and so it is important
 to be able to deal with them. But we cannot find the roots of an equation if we
 do not know all the coefficients. The best solution to this will depend on the
@@ -1450,9 +2695,24 @@ particular use case; perhaps we should throw an error. However, for this
 example, we will assume that the best solution is to propagate the missing
 values forward; that is, if any input is missing, we simply produce a missing
 output.
+-->
+```
+2次方程式の最大の実数根を見つけたいのだけれども、方程式の係数が欠損している可能性がある場合を考えてみましょう。
+データセットに欠損値があることは、実際にデータを扱う際によく起こるため、対処できるようにするのは重要です。
+しかし、すべての係数がわからなければ、方程式の根を見つけることはできません。
+個々の事例で変わるでしょうが、これに対する最良の解決方法は、
+おそらくエラーを投げることでしょう。
+しかし、この例では、欠落値を次に伝播することが最善策であると想定します。
+つまり、入力が欠落している場合は、単に出力も欠落したままにします。
 
+```@raw html
+<!--
 The `broadcast()` function makes this task easy; we can simply pass the
-`root` function we wrote to `broadcast`:
+`root` function we wrote to `broadcast`
+-->
+```
+`broadcast()`関数によって簡単に、この処理を行えます。さきほど書いた関数`root`を単に`broadcast`渡せばいいのです 。
+
 
 ```jldoctest nullableroot
 julia> broadcast(root, Nullable(1), Nullable(-9), Nullable(20))
@@ -1465,21 +2725,40 @@ julia> broadcast(root, Nullable{Int}(), Nullable(-9), Nullable(20))
 Nullable{Float64}()
 ```
 
+
+```@raw html
+<!--
 If one or more of the inputs is missing, then the output of
 `broadcast()` will be missing.
 
 There exists special syntactic sugar for the `broadcast()` function
 using a dot notation:
+-->
+```
+
+1つ以上の入力が欠落している場合、`broadcast()`の出力は、欠けたままです。
+
+`broadcast()`関数には、ドット表記を使用する特別な糖衣構文が存在します。
 
 ```jldoctest nullableroot
 julia> root.(Nullable(1), Nullable(-9), Nullable(20))
 Nullable{Float64}(5.0)
 ```
 
+
+```@raw html
+<!--
 In particular, the regular arithmetic operators can be `broadcast()`
 conveniently using `.`-prefixed operators:
+-->
+```
+
+特に、通常の算術演算子に対して、便利に`broadcast()`を使うことのできる、前置記法の`.`演算子があります。
 
 ```jldoctest
 julia> Nullable(2) ./ Nullable(3) .+ Nullable(1.0)
 Nullable{Float64}(1.66667)
-```
+``
+
+[訳注1]:"polymorphism"という言葉は、オブジェクト指向プログラミングでは「多態性」、関数型プログラミングでは「多相性」と訳されることが多いですが、この文書では統括して記述しているように思えたので、文脈で訳し分けることはせず、すべて「多相性」としました。
+[訳注2]:Juliaはver0.5とver0.6の間で型に関する用語を大きく変えており、この訳では`bits type`にver0.6の`primitive type`の訳である原始型を当てています。


### PR DESCRIPTION
「型」から「モジュール」まで一括更新しています。